### PR TITLE
chore(security): patch open Dependabot alerts (postcss + vite)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7450,34 +7450,6 @@
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9374,9 +9374,9 @@
       }
     },
     "node_modules/vitest/node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
     "typescript": "5.8.3",
     "typescript-eslint": "^8.31.0",
     "vitest": "^4.0.18"
+  },
+  "overrides": {
+    "postcss": "^8.5.15"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "vitest": "^4.0.18"
   },
   "overrides": {
-    "postcss": "^8.5.15"
+    "postcss": "^8.5.15",
+    "vite": "^7.3.3"
   }
 }


### PR DESCRIPTION
## Summary
- Adds an npm `overrides` block pinning two transitively-pulled packages to patched versions, closing **4 of 5** open Dependabot alerts on `main`.
- `postcss` → `^8.5.15` — fixes **#84** (medium, GHSA-7fh5-64p2-3v2j — XSS via unescaped `</style>` in CSS stringify). Previously next 15.3.9 pulled 8.4.31 and @tailwindcss/postcss + vite pulled 8.5.6.
- `vite` → `^7.3.3` — fixes **#60** (high, GHSA-v2wj-q39q-566r — `server.fs.deny` bypass), **#62** (high, GHSA-p9ff-h696-f583 — arbitrary file read via dev-server WebSocket), and **#61** (medium, GHSA-4w7w-66w2-5vf9 — path traversal in optimized deps `.map`). vitest 4.0.18 accepts vite `^6 || ^7`, so the 7.3.3 pin keeps the peer happy.

## Not addressed in this PR
- **#43** `@tootallnate/once` (low) — pulled in via `firebase-admin@13.x → google-cloud/storage → teeny-request → http-proxy-agent`. `npm audit` only offers `firebase-admin@10.3.0` as a fix, which is a major **downgrade** and would break the rest of the app. Worth a separate investigation (upstream firebase-admin needs to refresh its transport chain) rather than bundling here.

## Test plan
- [x] `npm test` — all 285 tests pass
- [x] `npm ls postcss` shows 8.5.15 everywhere (overridden)
- [x] `npm ls vite` shows 7.3.3 everywhere (overridden)
- [ ] After merge: confirm Dependabot auto-closes #60, #61, #62, #84 on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)