### PR TITLE
fix(footer): normalize Contact Us mailto syntax

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -39,7 +39,7 @@ export default function Footer() {
       <FooterLinks>
         <FooterLink href="https://donatalk.com/terms-of-service/">Terms of Service</FooterLink>
         <FooterLink href="https://donatalk.com/privacy-policy/">Privacy Policy</FooterLink>
-        <FooterLink href="mailto://support@donatalk.com">Contact Us</FooterLink>
+        <FooterLink href="mailto:support@donatalk.com">Contact Us</FooterLink>
       </FooterLinks>
     </FooterContainer>
   );


### PR DESCRIPTION
## Summary

`components/Footer.tsx:42` used `mailto://support@donatalk.com` for the **Contact Us** link (the rightmost link in the footer row, next to Terms of Service and Privacy Policy). The double-slash is not valid per RFC 6068 — most modern browsers tolerate it and still open the default mail app, but several email clients (Outlook, Apple Mail, iOS Mail, some webmail handlers) either ignore the link or open a blank composer with no recipient. Fixed to `mailto:support@donatalk.com`.

Recipient address itself was already correct.

## Audit context

This is the only mailto link that needed fixing. Audited every `mailto:` link and every plain-text `support@donatalk.com` mention in the codebase before fixing:

| Location | Status |
|---|---|
| `components/Footer.tsx:42` Contact Us | **fixed** (`mailto://` → `mailto:`) |
| `app/api/send-signup-email/route.ts:63` | already correct |
| `app/api/send-payment-confirm-email/route.ts:61` | already correct |
| `pages/listener/[uid].tsx:296` | already correct |
| `pages/pitcher/[uid].tsx:305` | already correct |
| `app/api/send-notification/route.ts:65` | dynamic pitcher↔listener mailto, intentionally not support (and route is the verified orphan we'll delete separately) |

Also grepped for `contact@donatalk`, `info@donatalk`, `hello@donatalk`, `help@donatalk`, `admin@donatalk`, `noreply@donatalk`, `no-reply@donatalk` — zero matches, so no stray non-support address was being used.

## Test plan
- [x] `rm -rf .next && npx tsc --noEmit` — clean
- [x] `npm test` — 279 / 279
- [ ] After merge: click "Contact Us" in the deployed footer and confirm the mail composer opens with `support@donatalk.com` pre-filled in the To: field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)