### PR TITLE
fix(signup): role-aware welcome email links + USD10 minimum donation

### DIFF
--- a/app/api/send-signup-email/route.ts
+++ b/app/api/send-signup-email/route.ts
@@ -12,6 +12,10 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: 'Missing required fields.' }, { status: 400 });
     }
 
+    if (role !== 'pitcher' && role !== 'listener') {
+      return NextResponse.json({ error: 'Invalid role.' }, { status: 400 });
+    }
+
     let customMsg1 = '';
     let customMsg2 = '';
     let customMsg3 = '';
@@ -25,6 +29,9 @@ export async function POST(req: Request) {
       customMsg2 = 'You can update your information at '
       customMsg3 = '';
     }
+
+    const profileUrl = `${APP_URL}/${role}/profile`;
+    const publicPageUrl = `${APP_URL}/${role}/${userId}`;
 
     const mailOptions = {
       to: [email],
@@ -49,12 +56,12 @@ export async function POST(req: Request) {
             </p>
 
             <p style="font-size: 16px; color: #333333;">
-              Your personal page has been created below. ${customMsg2} <a href="${APP_URL}/pitcher/profile"> your profile page</a>. ${customMsg3}
+              Your personal page has been created below. ${customMsg2} <a href="${profileUrl}"> your profile page</a>. ${customMsg3}
             </p>
 
             <blockquote style="background-color: #F8A5A5; margin: 5px; padding-top: 30px; padding-bottom: 10px; font-size: 16px; border-left: 5px solid #E74C3C; border-radius: 6px; color: #000000; white-space: pre-wrap; text-align: center; display: flex; align-items: center; justify-content: center; min-height: 50px; width: 100%;">
-              <a href="${APP_URL}/pitcher/${userId}" style="color: #2C3E50; text-decoration: none; font-weight: bold;">
-                ${APP_URL}/${role}/${userId}
+              <a href="${publicPageUrl}" style="color: #2C3E50; text-decoration: none; font-weight: bold;">
+                ${publicPageUrl}
               </a>
             </blockquote>
 

--- a/app/listener/signup/page.tsx
+++ b/app/listener/signup/page.tsx
@@ -22,6 +22,7 @@ import { Input, Textarea, Button, Field, Label } from '@/components/ui';
 import PageWrapper from '@/components/layout/PageWrapper';
 import CardContainer from '@/components/layout/CardContainer';
 import { Logo, Title, Subtitle, ErrorBox } from '@/components/ui/shared';
+import { MIN_DONATION_USD } from '@/lib/constants';
 import { styled } from '@/styles/stitches.config';
 import Script from 'next/script';
 
@@ -84,6 +85,10 @@ export default function SignupListener() {
     setError('');
     if (!form.fullName || !form.email || !form.password || !form.intro || !form.donation) {
       setError('Please fill in all fields.');
+      return;
+    }
+    if (parseFloat(form.donation) < MIN_DONATION_USD) {
+      setError(`Donation request per meeting must be at least $${MIN_DONATION_USD}.`);
       return;
     }
 
@@ -166,6 +171,8 @@ export default function SignupListener() {
           body: JSON.stringify({
             email: email || '',
             fullName: displayName || '',
+            userId: uid,
+            role: 'listener',
           }),
         });
       }
@@ -202,7 +209,7 @@ export default function SignupListener() {
       </Script>
 
       <Head>
-        <title>Sign Up as Pitcher | DonaTalk</title>
+        <title>Sign Up as Listener | DonaTalk</title>
         <meta name="description" content="Sign up as a listener and discover pitches that inspire donations." />
       </Head>
 
@@ -239,8 +246,8 @@ export default function SignupListener() {
           </Field>
 
           <Field>
-            <Label>Donation Request per Meeting ($)</Label>
-            <Input name="donation" type="number" value={form.donation} onChange={onChange} onKeyPress={handleKeyPress} />
+            <Label>Donation Request per Meeting ($ — minimum {MIN_DONATION_USD})</Label>
+            <Input name="donation" type="number" min={MIN_DONATION_USD} placeholder={`${MIN_DONATION_USD} or more`} value={form.donation} onChange={onChange} onKeyPress={handleKeyPress} />
           </Field>
 
           <Button onClick={handleSignup} disabled={loading}>

--- a/app/listener/update-profile/page.tsx
+++ b/app/listener/update-profile/page.tsx
@@ -21,6 +21,7 @@ import { Logo, Title, Subtitle, ErrorBox } from '@/components/ui/shared';
 import { Input, Textarea, Button, Field, Label } from '@/components/ui';
 import { styled } from '@/styles/stitches.config';
 import {Listener} from '@/types/listener'
+import { MIN_DONATION_USD } from '@/lib/constants';
 
 const Form = styled('div', {
   display: 'flex',
@@ -78,6 +79,10 @@ export default function ListenerUpdateProfile() {
   const handleUpdate = async () => {
     if (!form.fullName || !form.intro || !form.donation) {
       setError('Full Name, Intro, and Donation fields are required.');
+      return;
+    }
+    if (form.donation < MIN_DONATION_USD) {
+      setError(`Donation request per meeting must be at least $${MIN_DONATION_USD}.`);
       return;
     }
     setLoading(true);
@@ -139,8 +144,8 @@ export default function ListenerUpdateProfile() {
             </Field>
 
             <Field>
-              <Label>Donation Request per Meeting ($)</Label>
-              <Input name="donation" type="number" value={form.donation} onChange={onChange} />
+              <Label>Donation Request per Meeting ($ — minimum {MIN_DONATION_USD})</Label>
+              <Input name="donation" type="number" min={MIN_DONATION_USD} value={form.donation} onChange={onChange} />
             </Field>
 
             <Button onClick={handleUpdate} disabled={loading}>

--- a/app/pitcher/signup/page.tsx
+++ b/app/pitcher/signup/page.tsx
@@ -22,6 +22,7 @@ import { Input, Textarea, Button, Field, Label } from '@/components/ui';
 import PageWrapper from '@/components/layout/PageWrapper';
 import CardContainer from '@/components/layout/CardContainer';
 import { Logo, Title, Subtitle, ErrorBox } from '@/components/ui/shared';
+import { MIN_DONATION_USD } from '@/lib/constants';
 import { styled } from '@/styles/stitches.config';
 import Script from 'next/script';
 
@@ -84,6 +85,10 @@ export default function SignupPitcher() {
     setError('');
     if (!form.fullName || !form.email || !form.password || !form.aboutPitch || !form.donation) {
       setError('Please fill in all fields.');
+      return;
+    }
+    if (parseFloat(form.donation) < MIN_DONATION_USD) {
+      setError(`Donation per meeting must be at least $${MIN_DONATION_USD}.`);
       return;
     }
 
@@ -166,6 +171,8 @@ export default function SignupPitcher() {
           body: JSON.stringify({
             email: email || '',
             fullName: displayName || '',
+            userId: uid,
+            role: 'pitcher',
           }),
         });
       }
@@ -238,8 +245,8 @@ export default function SignupPitcher() {
           </Field>
 
           <Field>
-            <Label>Donation per Meeting ($)</Label>
-            <Input name="donation" type="number" value={form.donation} onChange={onChange} onKeyPress={handleKeyPress} />
+            <Label>Donation per Meeting ($ — minimum {MIN_DONATION_USD})</Label>
+            <Input name="donation" type="number" min={MIN_DONATION_USD} placeholder={`${MIN_DONATION_USD} or more`} value={form.donation} onChange={onChange} onKeyPress={handleKeyPress} />
           </Field>
 
           <Button onClick={handleSignup} disabled={loading}>

--- a/app/pitcher/update-profile/page.tsx
+++ b/app/pitcher/update-profile/page.tsx
@@ -20,6 +20,7 @@ import CardContainer from '@/components/layout/CardContainer';
 import { Logo, Title, Subtitle, ErrorBox } from '@/components/ui/shared';
 import { Input, Textarea, Button, Field, Label } from '@/components/ui';
 import { styled } from '@/styles/stitches.config';
+import { MIN_DONATION_USD } from '@/lib/constants';
 
 type Pitcher = {
   fullName: string;
@@ -86,6 +87,10 @@ export default function PitcherUpdateProfile() {
       setError('Full Name, About Pitch, and Donation fields are required.');
       return;
     }
+    if (form.donation < MIN_DONATION_USD) {
+      setError(`Donation per meeting must be at least $${MIN_DONATION_USD}.`);
+      return;
+    }
     setLoading(true);
     try {
       if (userId) {
@@ -145,8 +150,8 @@ export default function PitcherUpdateProfile() {
             </Field>
 
             <Field>
-              <Label>Donation Request per Meeting ($)</Label>
-              <Input name="donation" type="number" value={form.donation} onChange={onChange} />
+              <Label>Donation Request per Meeting ($ — minimum {MIN_DONATION_USD})</Label>
+              <Input name="donation" type="number" min={MIN_DONATION_USD} value={form.donation} onChange={onChange} />
             </Field>
 
             <Button onClick={handleUpdate} disabled={loading}>

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -6,6 +6,10 @@ export const PLATFORM_FEE_MULTIPLIER = 1 + (PLATFORM_FEE_PERCENTAGE / 100);
 export const MAX_PENDING_RESERVATIONS = 5;
 export const RESERVATION_TTL_DAYS = 14;
 
+// Floor for the per-meeting donation a profile can ask for. Sub-$10 asks made
+// the 4.9% fee round to pennies and undercut the "meaningful donation" pitch.
+export const MIN_DONATION_USD = 10;
+
 // After the listener accepts, money sits in escrow until both parties confirm
 // the meeting happened. If neither acts within this window, the meeting is
 // auto-refunded back to the pitcher.


### PR DESCRIPTION
## Summary
Quick wins on the signup funnel (the current growth bottleneck):

- **Welcome email link bug**: listeners received a share link whose href pointed to `/pitcher/{uid}` while the visible text showed `/listener/{uid}`; the "your profile page" link always went to `/pitcher/profile`. Both are now role-aware.
- **Google signups got no welcome email at all**: the client call omitted `userId`/`role`, the API returned 400, and nothing surfaced. Both signup pages now pass them.
- **Listener signup page `<title>`** said "Sign Up as Pitcher".
- **$10 minimum donation** (`MIN_DONATION_USD` in `lib/constants.ts`) enforced on pitcher/listener signup and update-profile forms. Sub-$10 asks made the 4.9% fee round to pennies.

## Testing
- `npx vitest run` — 299/299 pass
- `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
