### PR TITLE
feat(signup): slim invite-path signup straight into funding (Option B)

### DIFF
--- a/app/api/create-profiles/route.ts
+++ b/app/api/create-profiles/route.ts
@@ -43,6 +43,7 @@ export async function POST(req: Request) {
     }
 
     const batch = db.batch();
+    const profileSlug = slug || await generateUniqueSlug(fullName || 'user');
 
     if (role === 'pitcher') {
       batch.set(db.collection('pitchers').doc(uid), {
@@ -51,7 +52,7 @@ export async function POST(req: Request) {
         pitch: pitch || '',
         donation: typeof donation === 'number' ? donation : parseFloat(donation) || 0,
         credit_balance: 0,
-        slug,
+        slug: profileSlug,
         isSetUp: true,
         createdAt: FieldValue.serverTimestamp(),
       });
@@ -61,7 +62,7 @@ export async function POST(req: Request) {
         email,
         intro: '',
         donation: 0,
-        slug,
+        slug: profileSlug,
         isSetUp: false,
         createdAt: FieldValue.serverTimestamp(),
       });
@@ -71,7 +72,7 @@ export async function POST(req: Request) {
         email,
         intro: intro || '',
         donation: typeof donation === 'number' ? donation : parseFloat(donation) || 0,
-        slug,
+        slug: profileSlug,
         isSetUp: true,
         createdAt: FieldValue.serverTimestamp(),
       });
@@ -82,13 +83,11 @@ export async function POST(req: Request) {
         pitch: '',
         donation: 0,
         credit_balance: 0,
-        slug,
+        slug: profileSlug,
         isSetUp: false,
         createdAt: FieldValue.serverTimestamp(),
       });
     } else if (role === 'both-stubs') {
-      const profileSlug = slug || await generateUniqueSlug(fullName);
-
       batch.set(db.collection('pitchers').doc(uid), {
         fullName,
         email,

--- a/app/listener/signup/page.tsx
+++ b/app/listener/signup/page.tsx
@@ -15,7 +15,7 @@ function readReturnPath(): string | null {
 }
 import { createUserWithEmailAndPassword } from 'firebase/auth';
 import { auth, firestore } from '@/firebase/clientApp'; // ✅ Adjust path if needed
-import { doc, setDoc, Timestamp, collection, getDocs, query, where } from 'firebase/firestore';
+import { doc, setDoc, Timestamp, collection, getDoc, getDocs, query, where } from 'firebase/firestore';
 import { signInWithGoogle, checkProfilesExist } from '@/lib/googleAuth';
 import { GoogleSignInButton } from '@/components/ui/GoogleSignInButton';
 import { Input, Textarea, Button, Field, Label } from '@/components/ui';
@@ -23,6 +23,15 @@ import PageWrapper from '@/components/layout/PageWrapper';
 import CardContainer from '@/components/layout/CardContainer';
 import { Logo, Title, Subtitle, ErrorBox } from '@/components/ui/shared';
 import { MIN_DONATION_USD } from '@/lib/constants';
+import { useEffect } from 'react';
+
+// When signup is reached from a pitcher's public page (?return=/pitcher/{uid}),
+// the visitor's goal is to hear THAT pitch — intro/donation details about their
+// own listener page are deferred to safe defaults they can edit later.
+function invitePitcherUidFrom(returnPath: string | null): string | null {
+  const m = returnPath?.match(/^\/pitcher\/([A-Za-z0-9_-]+)/);
+  return m ? m[1] : null;
+}
 import { styled } from '@/styles/stitches.config';
 import Script from 'next/script';
 
@@ -75,6 +84,25 @@ export default function SignupListener() {
   });
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [inviteUid, setInviteUid] = useState<string | null>(null);
+  const [invitePitcher, setInvitePitcher] = useState<{ fullName: string } | null>(null);
+
+  useEffect(() => {
+    const uid = invitePitcherUidFrom(readReturnPath());
+    setInviteUid(uid);
+    if (!uid) return;
+    getDoc(doc(firestore, 'pitchers', uid))
+      .then((snap) => {
+        if (!snap.exists()) return;
+        const d = snap.data();
+        if (d.isSetUp !== false && !d.deletedAt) {
+          setInvitePitcher({ fullName: d.fullName || '' });
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  const isInvite = !!inviteUid;
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
@@ -83,11 +111,11 @@ export default function SignupListener() {
 
   const handleSignup = async () => {
     setError('');
-    if (!form.fullName || !form.email || !form.password || !form.intro || !form.donation) {
+    if (!form.fullName || !form.email || !form.password || (!isInvite && (!form.intro || !form.donation))) {
       setError('Please fill in all fields.');
       return;
     }
-    if (parseFloat(form.donation) < MIN_DONATION_USD) {
+    if (!isInvite && parseFloat(form.donation) < MIN_DONATION_USD) {
       setError(`Donation request per meeting must be at least $${MIN_DONATION_USD}.`);
       return;
     }
@@ -101,8 +129,8 @@ export default function SignupListener() {
       await setDoc(doc(firestore, 'listeners', uid), {
         fullName: form.fullName,
         email: form.email,
-        intro: form.intro,
-        donation: parseFloat(form.donation),
+        intro: isInvite ? '' : form.intro,
+        donation: isInvite ? MIN_DONATION_USD : parseFloat(form.donation),
         slug,
         isSetUp: true,
         createdAt: Timestamp.now(),
@@ -162,7 +190,11 @@ export default function SignupListener() {
             uid,
             fullName: displayName || '',
             email: email || '',
-            role: 'both-stubs',
+            // Invite flow: create a ready-to-request listener profile with safe
+            // defaults instead of stubs, so the visitor isn't detoured through
+            // update-profile before they can send a meeting request.
+            role: isInvite ? 'listener' : 'both-stubs',
+            ...(isInvite && { donation: MIN_DONATION_USD }),
           }),
         });
         await fetch('/api/send-signup-email', {
@@ -217,7 +249,15 @@ export default function SignupListener() {
         <CardContainer>
           <Logo src="/DonaTalk_icon_88x77.png" alt="DonaTalk Logo" />
           <Title>Sign Up as a Listener</Title>
-          <Subtitle>Discover pitches and support community.</Subtitle>
+          {isInvite ? (
+            <Subtitle>
+              One quick step before you can hear
+              {invitePitcher?.fullName ? ` ${invitePitcher.fullName}'s` : ' this'} pitch — their
+              donation goes to a cause you care about.
+            </Subtitle>
+          ) : (
+            <Subtitle>Discover pitches and support community.</Subtitle>
+          )}
 
           {error && <ProminentErrorBox>{error}</ProminentErrorBox>}
 
@@ -240,15 +280,19 @@ export default function SignupListener() {
             <Input name="password" type="password" value={form.password} onChange={onChange} onKeyPress={handleKeyPress} />
           </Field>
 
-          <Field>
-            <Label>Brief Intro or LinkedIn Page Link</Label>
-            <Textarea name="intro" rows={3} value={form.intro} onChange={onChange} />
-          </Field>
+          {!isInvite && (
+            <>
+              <Field>
+                <Label>Brief Intro or LinkedIn Page Link</Label>
+                <Textarea name="intro" rows={3} value={form.intro} onChange={onChange} />
+              </Field>
 
-          <Field>
-            <Label>Donation Request per Meeting ($ — minimum {MIN_DONATION_USD})</Label>
-            <Input name="donation" type="number" min={MIN_DONATION_USD} placeholder={`${MIN_DONATION_USD} or more`} value={form.donation} onChange={onChange} onKeyPress={handleKeyPress} />
-          </Field>
+              <Field>
+                <Label>Donation Request per Meeting ($ — minimum {MIN_DONATION_USD})</Label>
+                <Input name="donation" type="number" min={MIN_DONATION_USD} placeholder={`${MIN_DONATION_USD} or more`} value={form.donation} onChange={onChange} onKeyPress={handleKeyPress} />
+              </Field>
+            </>
+          )}
 
           <Button onClick={handleSignup} disabled={loading}>
             {loading ? 'Creating Account...' : 'Sign Up'}

--- a/app/pitcher/signup/page.tsx
+++ b/app/pitcher/signup/page.tsx
@@ -15,14 +15,23 @@ function readReturnPath(): string | null {
 }
 import { createUserWithEmailAndPassword } from 'firebase/auth';
 import { auth, firestore } from '@/firebase/clientApp'; // ✅ Adjust path if needed
-import { doc, setDoc, Timestamp, collection, getDocs, query, where } from 'firebase/firestore';
+import { doc, setDoc, Timestamp, collection, getDoc, getDocs, query, where } from 'firebase/firestore';
 import { signInWithGoogle, checkProfilesExist } from '@/lib/googleAuth';
 import { GoogleSignInButton } from '@/components/ui/GoogleSignInButton';
 import { Input, Textarea, Button, Field, Label } from '@/components/ui';
 import PageWrapper from '@/components/layout/PageWrapper';
 import CardContainer from '@/components/layout/CardContainer';
 import { Logo, Title, Subtitle, ErrorBox } from '@/components/ui/shared';
-import { MIN_DONATION_USD } from '@/lib/constants';
+import { MIN_DONATION_USD, calculateTotalWithFee } from '@/lib/constants';
+import { useEffect } from 'react';
+
+// When signup is reached from a listener's public page (?return=/listener/{uid}),
+// the visitor's goal is to book THAT listener — pitch/donation details about their
+// own future page are deferred to safe defaults they can edit later.
+function inviteListenerUidFrom(returnPath: string | null): string | null {
+  const m = returnPath?.match(/^\/listener\/([A-Za-z0-9_-]+)/);
+  return m ? m[1] : null;
+}
 import { styled } from '@/styles/stitches.config';
 import Script from 'next/script';
 
@@ -75,6 +84,37 @@ export default function SignupPitcher() {
   });
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [inviteUid, setInviteUid] = useState<string | null>(null);
+  const [inviteListener, setInviteListener] = useState<{ fullName: string; donation: number } | null>(null);
+
+  useEffect(() => {
+    const uid = inviteListenerUidFrom(readReturnPath());
+    setInviteUid(uid);
+    if (!uid) return;
+    getDoc(doc(firestore, 'listeners', uid))
+      .then((snap) => {
+        if (!snap.exists()) return;
+        const d = snap.data();
+        if (d.isSetUp !== false && !d.deletedAt) {
+          setInviteListener({ fullName: d.fullName || '', donation: Number(d.donation) || 0 });
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  const isInvite = !!inviteUid;
+
+  // After an invite signup, jump straight to PayPal preloaded with the amount
+  // this listener requires; add-fund returns to the listener page to book.
+  const nextAfterSignup = (): string => {
+    const returnTo = readReturnPath();
+    if (!returnTo) return '/pitcher/profile';
+    if (inviteUid && inviteListener && inviteListener.donation > 0) {
+      const required = calculateTotalWithFee(inviteListener.donation);
+      return `/pitcher/add-fund?min=${required}&return=${encodeURIComponent(returnTo)}`;
+    }
+    return returnTo;
+  };
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
@@ -83,11 +123,11 @@ export default function SignupPitcher() {
 
   const handleSignup = async () => {
     setError('');
-    if (!form.fullName || !form.email || !form.password || !form.aboutPitch || !form.donation) {
+    if (!form.fullName || !form.email || !form.password || (!isInvite && (!form.aboutPitch || !form.donation))) {
       setError('Please fill in all fields.');
       return;
     }
-    if (parseFloat(form.donation) < MIN_DONATION_USD) {
+    if (!isInvite && parseFloat(form.donation) < MIN_DONATION_USD) {
       setError(`Donation per meeting must be at least $${MIN_DONATION_USD}.`);
       return;
     }
@@ -101,8 +141,8 @@ export default function SignupPitcher() {
       await setDoc(doc(firestore, 'pitchers', uid), {
         fullName: form.fullName,
         email: form.email,
-        pitch: form.aboutPitch,
-        donation: parseFloat(form.donation),
+        pitch: isInvite ? '' : form.aboutPitch,
+        donation: isInvite ? MIN_DONATION_USD : parseFloat(form.donation),
         credit_balance: 0,
         slug, // 👈 save the unique slug here
         isSetUp: true,
@@ -131,7 +171,7 @@ export default function SignupPitcher() {
         }),
       });
 
-      router.push(readReturnPath() ?? '/pitcher/profile'); // ✅ Navigate after sending the email
+      router.push(nextAfterSignup()); // ✅ Navigate after sending the email
     } catch (err: unknown) {
       const error = err as Error;
       console.error(error.message);
@@ -162,7 +202,11 @@ export default function SignupPitcher() {
             uid,
             fullName: displayName || '',
             email: email || '',
-            role: 'both-stubs',
+            // Invite flow: create a ready-to-book pitcher profile with safe
+            // defaults instead of stubs, so the visitor isn't detoured through
+            // update-profile before they can fund and book.
+            role: isInvite ? 'pitcher' : 'both-stubs',
+            ...(isInvite && { donation: MIN_DONATION_USD }),
           }),
         });
         await fetch('/api/send-signup-email', {
@@ -177,7 +221,7 @@ export default function SignupPitcher() {
         });
       }
 
-      router.push(readReturnPath() ?? '/choose-a-profile');
+      router.push(isInvite ? nextAfterSignup() : (readReturnPath() ?? '/choose-a-profile'));
     } catch (err) {
       console.error('[Google Signup Error]', err);
       setError('An error occurred during Google sign-in. Please try again.');
@@ -216,7 +260,15 @@ export default function SignupPitcher() {
         <CardContainer>
           <Logo src="/DonaTalk_icon_88x77.png" alt="DonaTalk Logo" />
           <Title>Sign Up as a Pitcher</Title>
-          <Subtitle>Share your cause and connect with supporters</Subtitle>
+          {isInvite ? (
+            <Subtitle>
+              One quick step before you can pitch
+              {inviteListener?.fullName ? ` ${inviteListener.fullName}` : ''} — then add your
+              donation budget via PayPal and book your meeting.
+            </Subtitle>
+          ) : (
+            <Subtitle>Share your cause and connect with supporters</Subtitle>
+          )}
 
           {error && <ProminentErrorBox>{error}</ProminentErrorBox>}
 
@@ -239,15 +291,19 @@ export default function SignupPitcher() {
             <Input name="password" type="password" value={form.password} onChange={onChange} onKeyPress={handleKeyPress} />
           </Field>
 
-          <Field>
-            <Label>About Pitch (Brief Description)</Label>
-            <Textarea name="aboutPitch" rows={3} value={form.aboutPitch} onChange={onChange} />
-          </Field>
+          {!isInvite && (
+            <>
+              <Field>
+                <Label>About Pitch (Brief Description)</Label>
+                <Textarea name="aboutPitch" rows={3} value={form.aboutPitch} onChange={onChange} />
+              </Field>
 
-          <Field>
-            <Label>Donation per Meeting ($ — minimum {MIN_DONATION_USD})</Label>
-            <Input name="donation" type="number" min={MIN_DONATION_USD} placeholder={`${MIN_DONATION_USD} or more`} value={form.donation} onChange={onChange} onKeyPress={handleKeyPress} />
-          </Field>
+              <Field>
+                <Label>Donation per Meeting ($ — minimum {MIN_DONATION_USD})</Label>
+                <Input name="donation" type="number" min={MIN_DONATION_USD} placeholder={`${MIN_DONATION_USD} or more`} value={form.donation} onChange={onChange} onKeyPress={handleKeyPress} />
+              </Field>
+            </>
+          )}
 
           <Button onClick={handleSignup} disabled={loading}>
             {loading ? 'Creating Account...' : 'Sign Up'}


### PR DESCRIPTION
## Summary
Implements **Option B** of the signup-wall fix: keep forced sign-up, but when a visitor arrives via an invite link (`?return=/listener/{uid}` or `/pitcher/{uid}`), the funnel slims from 4–5 steps / 7 fields to **signup (3 fields or 1 Google click) → PayPal → book**.

- Invite-path signup hides the "About Pitch" / "Brief Intro" and "Donation per Meeting" questions; profiles are created `isSetUp:true` with safe defaults (empty text, $10 donation) the user can edit later — no update-profile detour.
- After an invite pitcher signup, the user is redirected straight to `/pitcher/add-fund?min=<exact amount for that listener>&return=<listener page>`, then back to the booking form. Listener-side invites return directly to the pitcher page request form.
- Google invite signups create a real role profile (`role:'pitcher'|'listener'`) instead of `both-stubs`, eliminating the stub → update-profile detour.
- `create-profiles` API now auto-generates a slug for `pitcher`/`listener` roles when none is provided (previously wrote `undefined` to Firestore).
- Contextual subtitle shows who the visitor is about to pitch/hear.

Non-invite (organic) signups are unchanged: full form, $10 minimum enforced.

## Testing
- `npx vitest run` — 299/299 pass
- `npx tsc --noEmit` — clean
- `npx next build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
