### PR TITLE
feat(analytics): GA4 site-wide + real conversion events

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,7 +4,7 @@ import Navbar from '../components/Navbar';           // ✅ Navbar component
 import Footer from '../components/Footer';           // ✅ Footer component
 import { Providers } from './providers';             // ✅ Added Theme Provider
 import LoadingScreen from '../components/LoadingScreen'; // ✅ Added Loading Screen
-import Script from 'next/script';
+import GoogleTag from '../components/GoogleTag';
 
 export const metadata = {
   title: 'DonaTalk',
@@ -14,19 +14,8 @@ export const metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className="light" suppressHydrationWarning>
-      {/* G Tag Manager */}
-      <Script
-        src="https://www.googletagmanager.com/gtag/js?id=AW-17050482317"
-        strategy="afterInteractive"
-      />
-      <Script id="gtag-init" strategy="afterInteractive">
-        {`
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', 'AW-17050482317');
-      `}
-      </Script>
+      {/* Google Ads + GA4 */}
+      <GoogleTag />
 
       <body>
         <Providers>

--- a/app/listener/signup/page.tsx
+++ b/app/listener/signup/page.tsx
@@ -33,7 +33,7 @@ function invitePitcherUidFrom(returnPath: string | null): string | null {
   return m ? m[1] : null;
 }
 import { styled } from '@/styles/stitches.config';
-import Script from 'next/script';
+import { trackSignup } from '@/lib/analytics';
 
 const Divider = styled('div', {
   display: 'flex',
@@ -159,6 +159,7 @@ export default function SignupListener() {
         }),
       });
 
+      trackSignup('listener', 'email');
       router.push(readReturnPath() ?? '/listener/profile'); // ✅ Navigate after sending the email
     } catch (err: unknown) {
       const error = err as Error;
@@ -207,6 +208,7 @@ export default function SignupListener() {
             role: 'listener',
           }),
         });
+        trackSignup('listener', 'google');
       }
 
       router.push(readReturnPath() ?? '/choose-a-profile');
@@ -226,20 +228,6 @@ export default function SignupListener() {
 
   return (
     <>
-      {/* G Tag Manager */}
-      <Script
-        src="https://www.googletagmanager.com/gtag/js?id=AW-17050482317"
-        strategy="afterInteractive"
-      />
-      <Script id="gtag-init" strategy="afterInteractive">
-        {`
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', 'AW-17050482317');
-      `}
-      </Script>
-
       <Head>
         <title>Sign Up as Listener | DonaTalk</title>
         <meta name="description" content="Sign up as a listener and discover pitches that inspire donations." />

--- a/app/pitcher/add-fund/page.tsx
+++ b/app/pitcher/add-fund/page.tsx
@@ -11,6 +11,7 @@ import { Logo, ErrorBox } from '@/components/ui/shared';
 import { styled } from '@/styles/stitches.config';
 import { auth, firestore } from '@/firebase/clientApp';
 import { getSafeReturnPath } from '@/lib/safeReturn';
+import { trackAddFund } from '@/lib/analytics';
 import {
   PageHeading,
   PageSubheading,
@@ -263,6 +264,7 @@ export default function PitcherAddFund() {
       }
       const result = await res.json();
       if (result.status === 'COMPLETED') {
+        trackAddFund(amount, data.orderID);
         setSuccessMessage(`✓ $${amount.toFixed(2)} added to your balance.`);
         // Refresh balance shown on this page.
         try {

--- a/app/pitcher/signup/page.tsx
+++ b/app/pitcher/signup/page.tsx
@@ -33,7 +33,7 @@ function inviteListenerUidFrom(returnPath: string | null): string | null {
   return m ? m[1] : null;
 }
 import { styled } from '@/styles/stitches.config';
-import Script from 'next/script';
+import { trackSignup } from '@/lib/analytics';
 
 const Divider = styled('div', {
   display: 'flex',
@@ -171,6 +171,7 @@ export default function SignupPitcher() {
         }),
       });
 
+      trackSignup('pitcher', 'email');
       router.push(nextAfterSignup()); // ✅ Navigate after sending the email
     } catch (err: unknown) {
       const error = err as Error;
@@ -219,6 +220,7 @@ export default function SignupPitcher() {
             role: 'pitcher',
           }),
         });
+        trackSignup('pitcher', 'google');
       }
 
       router.push(isInvite ? nextAfterSignup() : (readReturnPath() ?? '/choose-a-profile'));
@@ -238,19 +240,6 @@ export default function SignupPitcher() {
 
   return (
     <>
-      {/* Google Tag Manager */}
-      <Script
-        src="https://www.googletagmanager.com/gtag/js?id=AW-17050482317"
-        strategy="afterInteractive"
-      />
-      <Script id="gtag-init" strategy="afterInteractive">
-        {`
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', 'AW-17050482317');
-      `}
-      </Script>
       <Head>
         <title>Sign Up as Pitcher | DonaTalk</title>
         <meta name="description" content="Sign up as a pitcher to share your cause on DonaTalk." />

--- a/components/GoogleTag.tsx
+++ b/components/GoogleTag.tsx
@@ -1,0 +1,30 @@
+// components/GoogleTag.tsx
+'use client';
+
+import Script from 'next/script';
+
+// Google Ads conversion tag (existing) + GA4 measurement id (set
+// NEXT_PUBLIC_GA_MEASUREMENT_ID in Vercel; GA4 config is skipped when absent
+// so local dev doesn't pollute analytics).
+export const ADS_ID = 'AW-17050482317';
+export const GA_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || '';
+
+export default function GoogleTag() {
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID || ADS_ID}`}
+        strategy="afterInteractive"
+      />
+      <Script id="gtag-init" strategy="afterInteractive">
+        {`
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', '${ADS_ID}');
+        ${GA_ID ? `gtag('config', '${GA_ID}');` : ''}
+      `}
+      </Script>
+    </>
+  );
+}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,30 @@
+// lib/analytics.ts
+// Client-side event helpers. Safe no-ops when gtag isn't loaded (SSR, ad
+// blockers, missing env) so callers never need to guard.
+
+type GtagWindow = Window & { gtag?: (...args: unknown[]) => void };
+
+export function trackEvent(name: string, params?: Record<string, unknown>): void {
+  if (typeof window === 'undefined') return;
+  const w = window as GtagWindow;
+  if (typeof w.gtag !== 'function') return;
+  try {
+    w.gtag('event', name, params || {});
+  } catch {
+    // analytics must never break the app
+  }
+}
+
+/** GA4 standard sign_up event, tagged with our role + auth method. */
+export function trackSignup(role: 'pitcher' | 'listener', method: 'email' | 'google'): void {
+  trackEvent('sign_up', { method, role });
+}
+
+/** Fund deposit completed via PayPal — GA4 purchase event. */
+export function trackAddFund(amountUsd: number, orderId: string): void {
+  trackEvent('purchase', {
+    transaction_id: orderId,
+    value: amountUsd,
+    currency: 'USD',
+  });
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,6 +5,7 @@ import Head from 'next/head';
 import { globalCss } from '../styles/stitches.config';
 import dynamic from 'next/dynamic';
 import Footer from '../components/Footer';
+import GoogleTag from '../components/GoogleTag';
 
 // ✅ Use dynamic to disable SSR for Navbar if hydration mismatch persists
 const Navbar = dynamic(() => import('../components/Navbar'), { ssr: false });
@@ -18,6 +19,7 @@ export default function App({ Component, pageProps }: AppProps) {
         <title>DonaTalk</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
+      <GoogleTag />
       <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
         <Navbar />
         <main style={{ flexGrow: 1 }}>


### PR DESCRIPTION
## Summary
The site had **no analytics** — only the Google Ads tag (App Router only) with zero conversion events ever fired, and the public profile pages (Pages Router) carried no tag at all.

- `components/GoogleTag.tsx`: single gtag loader for the Ads tag (AW-17050482317) + GA4 via `NEXT_PUBLIC_GA_MEASUREMENT_ID` (set to `G-PZFW5SZBN7` in Vercel production; GA4 skipped when env absent).
- Mounted in `app/layout.tsx` **and** `pages/_app.tsx` → public profile pages now tracked. Removed the duplicated inline snippets from both signup pages (double-fired config).
- `lib/analytics.ts` no-op-safe helpers firing real events: `sign_up` (role + email/google) on both signup paths, `purchase` (orderID, value, USD) on successful PayPal add-fund capture.

GA4 property "DonaTalk / DonaTalk Web" created under yunyoungmokk@gmail.com; stream 15053513771 for app.donatalk.com.

## Testing
- `npx vitest run` — 299/299 pass
- `npx tsc --noEmit` — clean
- `npx next build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
