### PR TITLE
feat(analytics+funnel): Reddit pixel real-signup events; signup explainers

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import Footer from '../components/Footer';           // ✅ Footer component
 import { Providers } from './providers';             // ✅ Added Theme Provider
 import LoadingScreen from '../components/LoadingScreen'; // ✅ Added Loading Screen
 import GoogleTag from '../components/GoogleTag';
+import RedditPixel from '../components/RedditPixel';
 
 export const metadata = {
   title: 'DonaTalk',
@@ -14,8 +15,9 @@ export const metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className="light" suppressHydrationWarning>
-      {/* Google Ads + GA4 */}
+      {/* Google Ads + GA4 + Reddit */}
       <GoogleTag />
+      <RedditPixel />
 
       <body>
         <Providers>

--- a/app/listener/signup/page.tsx
+++ b/app/listener/signup/page.tsx
@@ -73,6 +73,20 @@ const ProminentErrorBox = styled(ErrorBox, {
   backgroundColor: '#ffe5e5',
 });
 
+const HowItWorks = styled('ol', {
+  width: '100%',
+  margin: '0 0 16px',
+  padding: '14px 16px 14px 34px',
+  backgroundColor: '#f8f6f4',
+  border: '1px solid #eee',
+  borderRadius: '8px',
+  fontSize: '14px',
+  color: '#333',
+  lineHeight: 1.55,
+  '& li': { marginBottom: '4px' },
+  '& strong': { color: '#3498DB' },
+});
+
 export default function SignupListener() {
   const router = useRouter();
   const [form, setForm] = useState({
@@ -245,6 +259,14 @@ export default function SignupListener() {
             </Subtitle>
           ) : (
             <Subtitle>Discover pitches and support community.</Subtitle>
+          )}
+
+          {!isInvite && (
+            <HowItWorks>
+              <li>Create your profile and name the cause you care about.</li>
+              <li>People who want to pitch you commit a <strong>$10+ donation</strong> to it.</li>
+              <li>You accept only the pitches you like — <strong>your charity gets paid</strong> for your time.</li>
+            </HowItWorks>
           )}
 
           {error && <ProminentErrorBox>{error}</ProminentErrorBox>}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -17,6 +17,7 @@ import Head from 'next/head';
 import { signInWithEmailAndPassword } from 'firebase/auth';
 import { auth } from '@/firebase/clientApp';
 import { signInWithGoogle, checkProfilesExist } from '@/lib/googleAuth';
+import { trackSignup } from '@/lib/analytics';
 import { GoogleSignInButton } from '@/components/ui/GoogleSignInButton';
 import { Input, Button, Field, Label } from '@/components/ui';
 import PageWrapper from '@/components/layout/PageWrapper';
@@ -147,6 +148,7 @@ export default function LoginPage() {
             role: 'pitcher',
           }),
         });
+        trackSignup('pitcher', 'google');
       }
 
       router.push(readReturnPath() ?? '/choose-a-profile');

--- a/app/pitcher/signup/page.tsx
+++ b/app/pitcher/signup/page.tsx
@@ -73,6 +73,20 @@ const ProminentErrorBox = styled(ErrorBox, {
   backgroundColor: '#ffe5e5',
 });
 
+const HowItWorks = styled('ol', {
+  width: '100%',
+  margin: '0 0 16px',
+  padding: '14px 16px 14px 34px',
+  backgroundColor: '#f8f6f4',
+  border: '1px solid #eee',
+  borderRadius: '8px',
+  fontSize: '14px',
+  color: '#333',
+  lineHeight: 1.55,
+  '& li': { marginBottom: '4px' },
+  '& strong': { color: '#C26148' },
+});
+
 export default function SignupPitcher() {
   const router = useRouter();
   const [form, setForm] = useState({
@@ -257,6 +271,14 @@ export default function SignupPitcher() {
             </Subtitle>
           ) : (
             <Subtitle>Share your cause and connect with supporters</Subtitle>
+          )}
+
+          {!isInvite && (
+            <HowItWorks>
+              <li>Find a person you want to pitch on DonaTalk.</li>
+              <li>Commit a <strong>$10+ donation</strong> to the cause they care about.</li>
+              <li>They accept, you meet — their charity gets paid. <strong>No acceptance, no charge.</strong></li>
+            </HowItWorks>
           )}
 
           {error && <ProminentErrorBox>{error}</ProminentErrorBox>}

--- a/components/RedditPixel.tsx
+++ b/components/RedditPixel.tsx
@@ -1,0 +1,22 @@
+// components/RedditPixel.tsx
+'use client';
+
+import Script from 'next/script';
+
+// Reddit conversion pixel. Set NEXT_PUBLIC_REDDIT_PIXEL_ID in Vercel; skipped
+// when absent so local dev stays clean. PageVisit fires on load; SignUp and
+// Purchase are fired from lib/analytics.ts alongside the GA4 events.
+export const REDDIT_PIXEL_ID = process.env.NEXT_PUBLIC_REDDIT_PIXEL_ID || '';
+
+export default function RedditPixel() {
+  if (!REDDIT_PIXEL_ID) return null;
+  return (
+    <Script id="reddit-pixel" strategy="afterInteractive">
+      {`
+      !function(w,d){if(!w.rdt){var p=w.rdt=function(){p.sendEvent?p.sendEvent.apply(p,arguments):p.callQueue.push(arguments)};p.callQueue=[];var t=d.createElement("script");t.src="https://www.redditstatic.com/ads/pixel.js";t.async=true;var s=d.getElementsByTagName("script")[0];s.parentNode.insertBefore(t,s)}}(window,document);
+      rdt('init','${REDDIT_PIXEL_ID}');
+      rdt('track','PageVisit');
+    `}
+    </Script>
+  );
+}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -2,11 +2,14 @@
 // Client-side event helpers. Safe no-ops when gtag isn't loaded (SSR, ad
 // blockers, missing env) so callers never need to guard.
 
-type GtagWindow = Window & { gtag?: (...args: unknown[]) => void };
+type TagWindow = Window & {
+  gtag?: (...args: unknown[]) => void;
+  rdt?: (...args: unknown[]) => void;
+};
 
 export function trackEvent(name: string, params?: Record<string, unknown>): void {
   if (typeof window === 'undefined') return;
-  const w = window as GtagWindow;
+  const w = window as TagWindow;
   if (typeof w.gtag !== 'function') return;
   try {
     w.gtag('event', name, params || {});
@@ -15,16 +18,29 @@ export function trackEvent(name: string, params?: Record<string, unknown>): void
   }
 }
 
-/** GA4 standard sign_up event, tagged with our role + auth method. */
-export function trackSignup(role: 'pitcher' | 'listener', method: 'email' | 'google'): void {
-  trackEvent('sign_up', { method, role });
+function trackReddit(eventName: string, params?: Record<string, unknown>): void {
+  if (typeof window === 'undefined') return;
+  const w = window as TagWindow;
+  if (typeof w.rdt !== 'function') return;
+  try {
+    w.rdt('track', eventName, params || {});
+  } catch {
+    // analytics must never break the app
+  }
 }
 
-/** Fund deposit completed via PayPal — GA4 purchase event. */
+/** Real account creation — GA4 sign_up + Reddit SignUp. */
+export function trackSignup(role: 'pitcher' | 'listener', method: 'email' | 'google'): void {
+  trackEvent('sign_up', { method, role });
+  trackReddit('SignUp');
+}
+
+/** Fund deposit completed via PayPal — GA4 purchase + Reddit Purchase. */
 export function trackAddFund(amountUsd: number, orderId: string): void {
   trackEvent('purchase', {
     transaction_id: orderId,
     value: amountUsd,
     currency: 'USD',
   });
+  trackReddit('Purchase', { value: amountUsd, currency: 'USD', transactionId: orderId });
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,6 +6,7 @@ import { globalCss } from '../styles/stitches.config';
 import dynamic from 'next/dynamic';
 import Footer from '../components/Footer';
 import GoogleTag from '../components/GoogleTag';
+import RedditPixel from '../components/RedditPixel';
 
 // ✅ Use dynamic to disable SSR for Navbar if hydration mismatch persists
 const Navbar = dynamic(() => import('../components/Navbar'), { ssr: false });
@@ -20,6 +21,7 @@ export default function App({ Component, pageProps }: AppProps) {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
       <GoogleTag />
+      <RedditPixel />
       <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
         <Navbar />
         <main style={{ flexGrow: 1 }}>


### PR DESCRIPTION
- New components/RedditPixel.tsx (NEXT_PUBLIC_REDDIT_PIXEL_ID, set to
  a2_j5pzjyb21y6z in Vercel prod): PageVisit on load, mounted in both
  routers. lib/analytics.ts now also fires Reddit SignUp on real account
  creation and Reddit Purchase (with value) on PayPal capture - so the
  Reddit campaign can use actual signups as its conversion goal, not
  clicks.
- Login page's first-time-Google path now fires trackSignup (was the
  one signup path without the event).
- Signup pages gain a compact "How DonaTalk works" 3-step explainer
  (organic visits only; invite flow stays slim) - cold ad traffic needs
  to understand the product before being asked to register.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
