### PR TITLE
feat(seo): app SEO foundation — robots, sitemap, metadata, JSON-LD (v0.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to DonaTalk are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [SemVer](https://semver.org/).
 
+## [0.12.0] - 2026-07-09
+
+### Added (SEO foundation)
+- `app/robots.ts` — robots.txt allowing public pages, disallowing admin/API/auth-gated routes, pointing to the sitemap.
+- `app/sitemap.ts` — dynamic sitemap covering static routes + all public (non-deleted, set-up) listener & pitcher profiles.
+- Rich root metadata in `app/layout.tsx`: `metadataBase`, title template, Open Graph + Twitter cards, keywords, canonical.
+- Organization + WebSite JSON-LD (schema.org) in the root layout.
+- Per-profile SEO on public listener/pitcher pages: title, description, canonical, OG/Twitter, and ProfilePage/Person JSON-LD, rendered in SSR HTML; unavailable profiles marked `noindex`.
+
 ## [0.11.1] - 2026-05-23
 
 ### Added (admin dashboard — merged from feat/admin-quickwins)

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 // /app/layout.tsx
 import '../styles/globals.css';                      // ✅ Global styles
+import type { Metadata } from 'next';
 import Navbar from '../components/Navbar';           // ✅ Navbar component
 import Footer from '../components/Footer';           // ✅ Footer component
 import { Providers } from './providers';             // ✅ Added Theme Provider
@@ -7,9 +8,66 @@ import LoadingScreen from '../components/LoadingScreen'; // ✅ Added Loading Sc
 import GoogleTag from '../components/GoogleTag';
 import RedditPixel from '../components/RedditPixel';
 
-export const metadata = {
-  title: 'DonaTalk',
-  description: 'Share your cause and connect with supporters',
+const BASE = process.env.NEXT_PUBLIC_BASE_URL ?? 'https://app.donatalk.com';
+
+const OG_DESCRIPTION =
+  'Warm introductions that fund a cause. Pitchers donate to a non-profit to earn a meeting; listeners direct the donation to a cause they care about.';
+
+export const metadata: Metadata = {
+  metadataBase: new URL(BASE),
+  title: {
+    default: 'DonaTalk — Turn sales pitches into charitable donations',
+    template: '%s | DonaTalk',
+  },
+  description:
+    'DonaTalk turns cold outreach into warm introductions: pitchers donate to a non-profit to earn a meeting, and listeners send that donation to a cause they care about.',
+  applicationName: 'DonaTalk',
+  keywords: [
+    'warm introductions',
+    'cold email alternatives',
+    'donation-based outreach',
+    'charitable sales outreach',
+    'book a meeting for charity',
+    'B2B sales meetings',
+  ],
+  alternates: { canonical: '/' },
+  openGraph: {
+    type: 'website',
+    siteName: 'DonaTalk',
+    url: BASE,
+    title: 'DonaTalk — Turn sales pitches into charitable donations',
+    description: OG_DESCRIPTION,
+    images: [{ url: '/logo%20horizontal%20with%20text.png', alt: 'DonaTalk' }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'DonaTalk — Turn sales pitches into charitable donations',
+    description: OG_DESCRIPTION,
+    images: ['/logo%20horizontal%20with%20text.png'],
+  },
+  robots: { index: true, follow: true },
+};
+
+const orgJsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'Organization',
+      '@id': `${BASE}/#organization`,
+      name: 'DonaTalk',
+      url: BASE,
+      logo: `${BASE}/DonaTalk_icon_88x77.png`,
+      description:
+        'DonaTalk turns sales pitches into charitable donations — warm introductions that fund a non-profit.',
+    },
+    {
+      '@type': 'WebSite',
+      '@id': `${BASE}/#website`,
+      name: 'DonaTalk',
+      url: BASE,
+      publisher: { '@id': `${BASE}/#organization` },
+    },
+  ],
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -20,6 +78,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <RedditPixel />
 
       <body>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(orgJsonLd) }}
+        />
         <Providers>
           <LoadingScreen>
             <Navbar />                               {/* ✅ Added Navbar */}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,31 @@
+import type { MetadataRoute } from 'next';
+
+const BASE = process.env.NEXT_PUBLIC_BASE_URL ?? 'https://app.donatalk.com';
+
+// Public: /, /listeners, /login, signup pages, and public profiles /{role}/{uid}.
+// Private (crawlers excluded): admin, API, auth-gated dashboards and money flows.
+// NOTE: disallow specific sub-paths, never the bare /pitcher or /listener prefix —
+// that would block the public profile pages we want indexed.
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: [
+          '/admin',
+          '/api/',
+          '/choose-a-profile',
+          '/checkout',
+          '/pitcher/add-fund',
+          '/pitcher/update-profile',
+          '/pitcher/profile',
+          '/listener/update-profile',
+          '/listener/profile',
+        ],
+      },
+    ],
+    sitemap: `${BASE}/sitemap.xml`,
+    host: BASE,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,62 @@
+import type { MetadataRoute } from 'next';
+
+const BASE = process.env.NEXT_PUBLIC_BASE_URL ?? 'https://app.donatalk.com';
+
+// Generated per-request (not prerendered at build) — mirrors the /listeners
+// page, which also reads Firestore with the client SDK. Firebase is imported
+// lazily inside the function so `next build` never initializes it (no env at
+// build time); reads are wrapped so a failure degrades to the static routes.
+export const dynamic = 'force-dynamic';
+
+// Same public-visibility gate the browse page and profile pages use:
+// a profile is public only when isSetUp !== false AND not soft-deleted.
+async function publicProfileIds(coll: 'listeners' | 'pitchers'): Promise<string[]> {
+  try {
+    const { collection, getDocs } = await import('firebase/firestore');
+    const { firestore } = await import('@/firebase/clientApp');
+    const snap = await getDocs(collection(firestore, coll));
+    return snap.docs
+      .filter((d) => {
+        const x = d.data() as { isSetUp?: boolean; deletedAt?: unknown };
+        return x.isSetUp !== false && !x.deletedAt;
+      })
+      .map((d) => d.id);
+  } catch (err) {
+    console.error(`[sitemap] failed to read ${coll}`, err);
+    return [];
+  }
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const now = new Date();
+
+  const staticRoutes: MetadataRoute.Sitemap = [
+    { url: `${BASE}/`, lastModified: now, changeFrequency: 'daily', priority: 1 },
+    { url: `${BASE}/listeners`, lastModified: now, changeFrequency: 'daily', priority: 0.9 },
+    { url: `${BASE}/pitcher/signup`, lastModified: now, changeFrequency: 'monthly', priority: 0.6 },
+    { url: `${BASE}/listener/signup`, lastModified: now, changeFrequency: 'monthly', priority: 0.6 },
+    { url: `${BASE}/login`, lastModified: now, changeFrequency: 'monthly', priority: 0.3 },
+  ];
+
+  const [listeners, pitchers] = await Promise.all([
+    publicProfileIds('listeners'),
+    publicProfileIds('pitchers'),
+  ]);
+
+  const profileRoutes: MetadataRoute.Sitemap = [
+    ...listeners.map((id) => ({
+      url: `${BASE}/listener/${id}`,
+      lastModified: now,
+      changeFrequency: 'weekly' as const,
+      priority: 0.7,
+    })),
+    ...pitchers.map((id) => ({
+      url: `${BASE}/pitcher/${id}`,
+      lastModified: now,
+      changeFrequency: 'weekly' as const,
+      priority: 0.7,
+    })),
+  ];
+
+  return [...staticRoutes, ...profileRoutes];
+}

--- a/docs/company/OKR.md
+++ b/docs/company/OKR.md
@@ -16,9 +16,9 @@
 
 | KR | Target | Measure | Status |
 |----|--------|---------|--------|
-| **2-1** | Keyword-strategy doc: **3 validated non-branded clusters** (volume + difficulty), each mapped to a target page. | `plans/seo-keyword-strategy.md` | ⬜ not started |
+| **2-1** | Keyword-strategy doc: **3 validated non-branded clusters** (volume + difficulty), each mapped to a target page. | `plans/seo-keyword-strategy.md` | ✅ done 2026-07-09 (clusters A/B/C; volumes SERP-inferred, confirm w/ tool) |
 | **2-2** | GSC verified on **both** `donatalk.com` and `app.donatalk.com`; sitemaps submitted; baseline captured (indexed pages, impressions, avg position, top-10 queries); metric funnel defined. | `metrics/` + GSC | 🟡 GSC+GA4 confirmed, baseline captured 2026-07-09; app sitemap still to submit (→2-2a) |
-| **2-2a** | App SEO foundation shipped: `app/robots.ts`, `app/sitemap.ts`, OG/Twitter tags, per-profile metadata, JSON-LD. | app source + deploy | ⬜ not started (no blocker) |
+| **2-2a** | App SEO foundation shipped: `app/robots.ts`, `app/sitemap.ts`, OG/Twitter tags, per-profile metadata, JSON-LD. | app source + deploy | 🟡 built + verified (tsc/tests/build green) 2026-07-09; PR pending deploy |
 | **2-3** | ≥ **[TBD after baseline]** do-follow backlinks from ≥ **[TBD]** distinct domains, tracked in `backlink-ledger.md`. | `metrics/backlink-ledger.md` | ⬜ not started |
 
 ### Open sizing

--- a/docs/company/plans/seo-keyword-strategy.md
+++ b/docs/company/plans/seo-keyword-strategy.md
@@ -1,0 +1,78 @@
+# DonaTalk — SEO Keyword Strategy
+
+> generated 2026-07-09
+
+## 0. Context & method
+
+DonaTalk turns a sales pitch into a charitable donation: a **Pitcher** commits a donation to a non-profit in exchange for a warm intro, and a **Listener** agrees to hear the pitch and directs the donation to a cause they choose. Positioning line: *"What if every sales call also helped a non-profit?"* Revenue is a 4.9% fee on donations across two surfaces — `donatalk.com` (WordPress marketing/blog) and `app.donatalk.com` (the product).
+
+**Current reality:** near-zero non-branded discovery. GSC 28-day = 4 clicks / 37 impressions, all queries branded misspellings. So this strategy is about **manufacturing demand capture**, not harvesting existing brand demand.
+
+**Honesty note on the numbers:** No Ahrefs/Semrush/GSC keyword data on this pass. Volume figures are **rough US estimates inferred from SERP density, autocomplete, People-Also-Ask, competitor content depth, and forum activity** — not tool-confirmed. Every cluster carries a "confirm with a real tool" flag. Order-of-magnitude, not precise.
+
+Two facts shaped the clustering:
+1. **The exact-match category ("donation for a meeting", "book a meeting for charity") is nearly empty** — only two thin competitors (Influence Board, live; HearMeOut, an EA-forum beta concept). Low competition, but low existing volume — demand DonaTalk must *create*.
+2. **The adjacent category ("cold email alternatives", "warm introductions", "book meetings with executives") is huge and buyer-relevant** — but dominated by well-resourced SaaS blogs. Capture existing demand by inserting DonaTalk into the consideration set.
+
+Strategy: harvest adjacent demand at the top, funnel into the category DonaTalk can own at the bottom.
+
+## 1. Three non-branded keyword clusters
+
+### Cluster A — "Cold email / cold outreach alternatives" (adjacent demand capture)
+People who feel the pain DonaTalk solves (1% reply rates) and are shopping for a different approach. High commercial intent, high volume, most competitive.
+- **Head:** cold email alternatives
+- **Long-tails:** alternatives to cold calling · cold outreach alternatives · cold email vs cold call · what to do instead of cold email · cold email is dead alternatives · better ways to book B2B meetings · fill pipeline without cold email
+- **Est. volume (US):** head ~1–3k; "alternatives to cold calling" ~2–5k; long-tails 100–800 each. *Confirm.*
+- **Difficulty:** Medium-High. Saturated SaaS listicles (Breakcold, Prospeo, SmartReach, Saleshandy, Commsor, Abstrakt, Vida). Long-tails are softer and winnable with a differentiated angle.
+- **Intent:** Commercial-investigational → informational.
+
+### Cluster B — "Warm introductions / warm outreach" (relationship-selling demand)
+The category buyers move *toward* when they abandon cold outreach. DonaTalk = buy a warm intro by donating to a cause — owning this vocabulary is core.
+- **Head:** warm introduction (sales) / how to get warm intros
+- **Long-tails:** what is a warm introduction · how to ask for a warm intro · warm intro email template · warm intro vs cold outreach · how to get warm introductions B2B · book meetings with hard-to-reach executives · get meetings with C-suite
+- **Est. volume (US):** head ~800–2k; template/how-to long-tails 100–600 each; "meetings with executives" sub-cluster ~500–1.5k. *Confirm.*
+- **Difficulty:** Medium. Fragmented, less SEO-hardened competition (Scout, Vieu, Commsor, Draftboard, Upcell, Launch Leads, LinkedIn blog). Winnable with a strong pillar + template assets.
+- **Intent:** Informational + commercial tail on "meetings with executives".
+
+### Cluster C — "Donation-based outreach / book a meeting for charity" (the ownable category)
+Blue-ocean. Almost no competition, almost no *existing* volume — a category DonaTalk must name and create. Lowest near-term traffic, highest strategic value.
+- **Head:** donation-based outreach / book a meeting for charity
+- **Long-tails:** donate to charity for a meeting · pay to pitch charity · charity for a sales meeting · sell your calendar time to charity · what if every sales call helped a non-profit · charitable sales outreach platform · sales pitch donation
+- **Est. volume (US):** very low today (<100/mo per term, several near-zero). Latent/emerging. *Confirm; expect thin data.*
+- **Difficulty:** Low. Only Influence Board (live) + HearMeOut (beta). DonaTalk can rank #1 fast and *define the vocabulary*.
+- **Intent:** Commercial-to-transactional — searchers want the *product*.
+
+## 2. Cluster → target page
+
+| Cluster | Target page | Surface | Why |
+|---|---|---|---|
+| A — Cold email alternatives | blog listicle `donatalk.com/blog/cold-email-alternatives` | **WordPress** | Winning format is an editorial listicle; DonaTalk is the differentiated entry, funnels to app. |
+| B — Warm introductions | pillar + template `donatalk.com/blog/how-to-get-warm-introductions` (+ `/warm-intro-email-template`) | **WordPress** | Informational = blog pillar + cluster; internal-link to app `/listeners`, `/pitchers`. |
+| C — Donation-based outreach | `app.donatalk.com/listeners`, `/pitchers`, future `/vs` + impact calculator | **App** (+ thin WP explainer) | Transactional intent belongs on the product; own exact-match terms, convert directly. |
+
+Rule: informational + listicle → WordPress; commercial/transactional + category-defining → app.
+
+## 3. Angle assessment
+- **Cold email alternatives** — real, high volume, high competition → Cluster A.
+- **Warm intro / warm outreach** — real, medium, winnable, on-core → Cluster B.
+- **Book meetings with executives** — real, medium, high buyer intent → fold into B.
+- **Donation-based outreach** — ownable, low current volume → Cluster C (category creation).
+- **LinkedIn outreach that works** — huge but too competitive & off-core → skip as primary.
+- **Cause marketing / GivingTuesday** — wrong audience (nonprofit marketers) → skip for lead-gen.
+- **Gifting to book meetings (Reachdesk)** — adjacent, off-core → only a `/vs` comparison point.
+
+## 4. Competitor / SERP note
+- **A:** SaaS blogs; format = 10–15 item listicle updated for the year. Compete by matching format + a novel entry (charity-funded warm intros) none of them list.
+- **B:** Vieu/Scout/Commsor/Draftboard/etc.; format = definitional pillar + how-to + templates; thinner backlinks → beatable.
+- **C:** Influence Board + HearMeOut; no dominant format — whoever publishes the clear definition + comparison + calculator owns it.
+- **The gap DonaTalk owns:** no one sits at the intersection. Cold-email listicles never mention donation-based outreach; warm-intro guides never mention you can *buy* a warm intro by funding a cause. **Wedge: "donation-based / charitable warm outreach for everyday B2B sellers."**
+
+## 5. First three pieces of content (prioritized)
+1. **Listicle (A):** `donatalk.com/blog/cold-email-alternatives` — "11 Cold Email Alternatives That Actually Get Replies in 2026." Feature DonaTalk as the standout. Biggest near-term traffic; builds topical relevance.
+2. **Pillar + template (B):** `donatalk.com/blog/how-to-get-warm-introductions` — lead with warm-intro reply-rate stats, introduce donation-based warm intros, ship a downloadable template. On-core, winnable, bridges to C.
+3. **Category + explainer (C):** optimize app `/listeners` + `/pitchers` for exact-match terms; publish WP `what-is-donation-based-outreach` as the citable definition; build a `/vs` page. Ranks fast once the site has any authority. Impact calculator is a strong fast-follow.
+
+**Sequencing:** 1 pulls adjacent demand + authority → 2 deepens core + bridges → 3 captures/converts on the owned category. Re-check GSC 4–8 weeks after publishing; double down on whichever cluster gains impressions first.
+
+## Sources
+See research transcript (2026-07-09): Saleshandy, Breakcold, Prospeo, SmartReach, Vida, Abstrakt, Instantly, Cleanlist, Scout (askscout.ai), Vieu, Commsor, Draftboard, Launch Leads, OutboundSystem, BeExecutiveEvents, Influence Board, EA Forum (HearMeOut), Reachdesk, Expandi, Martal, ClearB2B, GivingTuesday.

--- a/docs/company/reports/2026-07-09-daily.md
+++ b/docs/company/reports/2026-07-09-daily.md
@@ -13,9 +13,13 @@
 - **Rotate** the WordPress Application Password — it transited chat in plaintext. Generate fresh, revoke old.
 - Still pending board: always-on scheduler host; approved posting accounts.
 
+## Execution (afternoon)
+- **KR2-1 done:** SEO keyword strategy written (`plans/seo-keyword-strategy.md`) — 3 non-branded clusters (A cold-email-alternatives, B warm-introductions, C donation-based-outreach) mapped to pages. Volumes SERP-inferred; flagged for tool confirmation.
+- **KR2-2a built + verified (v0.12.0):** `app/robots.ts`, dynamic `app/sitemap.ts` (public profiles), rich root metadata + Org/WebSite JSON-LD, per-profile OG/Twitter + ProfilePage JSON-LD (SSR, noindex for unavailable). Deploy gates green: tsc clean, 299 tests pass, production build succeeds (robots.txt + sitemap.xml emit). PR opened; on merge → Vercel deploy → probe → submit app sitemap to GSC.
+
 ## Next
-- KR2-2a app SEO foundation (robots, sitemap, OG, JSON-LD) — no blockers.
-- KR2-1 keyword clusters (growth-research routine).
+- Merge SEO PR → verify Vercel deploy → post-deploy health probe → submit `app.donatalk.com/sitemap.xml` to GSC.
+- KR2-3 backlinks (blocked: posting accounts). Content pieces from strategy (WordPress).
 
 ## Alerts
 - None.

--- a/docs/developer-reference.md
+++ b/docs/developer-reference.md
@@ -1,6 +1,6 @@
 # DonaTalk - Developer Reference
 
-> Last updated: 2026-05-19 | Version: 0.9.0
+> Last updated: 2026-07-09 | Version: 0.12.0
 
 ## Project Overview
 

--- a/docs/product-reference.md
+++ b/docs/product-reference.md
@@ -1,6 +1,6 @@
 # DonaTalk - Product Reference
 
-> Last updated: 2026-05-19 | Version: 0.9.0
+> Last updated: 2026-07-09 | Version: 0.12.0
 
 ## Product Vision
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pitcher-platform",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/pages/listener/[uid].tsx
+++ b/pages/listener/[uid].tsx
@@ -1,6 +1,7 @@
 // pages/listener/[uid].tsx
 
 import { GetServerSideProps } from 'next';
+import Head from 'next/head';
 import { doc, getDoc } from 'firebase/firestore';
 import { onAuthStateChanged, User } from 'firebase/auth';
 import { auth, firestore } from '../../firebase/clientApp';
@@ -85,7 +86,76 @@ function firstNameOf(full: string): string {
   return (full || '').trim().split(/\s+/)[0] || full || 'them';
 }
 
+const BASE = process.env.NEXT_PUBLIC_BASE_URL ?? 'https://app.donatalk.com';
+
+// Per-profile SEO head. Rendered outside the `hydrated` gate so the tags are
+// present in the SSR HTML. Unavailable profiles (stub / soft-deleted / missing)
+// are marked noindex.
+function ListenerHead({ listener, uid }: { listener: Listener | null; uid: string }) {
+  const url = `${BASE}/listener/${uid}`;
+  const available = !!listener && listener.isSetUp !== false && !listener.deletedAt;
+
+  if (!available) {
+    return (
+      <Head>
+        <meta name="robots" content="noindex, follow" />
+        <link rel="canonical" href={url} />
+      </Head>
+    );
+  }
+
+  const name = listener.fullName || 'A DonaTalk listener';
+  const intro = (listener.intro || '').trim();
+  const description = (
+    intro
+      ? `${name} on DonaTalk — ${intro}`
+      : `Pitch to ${name} on DonaTalk. Your donation books time with them and supports their chosen non-profit.`
+  ).slice(0, 155);
+  const title = `${name} — pitch & donate to their cause`;
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'ProfilePage',
+    url,
+    mainEntity: {
+      '@type': 'Person',
+      name,
+      ...(intro ? { description: intro } : {}),
+      url,
+    },
+  };
+
+  return (
+    <Head>
+      <title>{`${title} | DonaTalk`}</title>
+      <meta name="description" content={description} />
+      <link rel="canonical" href={url} />
+      <meta property="og:type" content="profile" />
+      <meta property="og:site_name" content="DonaTalk" />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:url" content={url} />
+      <meta property="og:image" content={`${BASE}/DonaTalk_icon_88x77.png`} />
+      <meta name="twitter:card" content="summary" />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+    </Head>
+  );
+}
+
 export default function ListenerPage({ listener, uid }: { listener: Listener | null; uid: string }) {
+  return (
+    <>
+      <ListenerHead listener={listener} uid={uid} />
+      <ListenerPageBody listener={listener} uid={uid} />
+    </>
+  );
+}
+
+function ListenerPageBody({ listener, uid }: { listener: Listener | null; uid: string }) {
   const [hydrated, setHydrated] = useState(false);
   const [user, setUser] = useState<User | null>(null);
   const [authResolved, setAuthResolved] = useState(false);

--- a/pages/pitcher/[uid].tsx
+++ b/pages/pitcher/[uid].tsx
@@ -1,6 +1,7 @@
 // pages/pitcher/[uid].tsx
 
 import { GetServerSideProps } from 'next';
+import Head from 'next/head';
 import { doc, getDoc } from 'firebase/firestore';
 import { onAuthStateChanged, User } from 'firebase/auth';
 import { auth, firestore } from '../../firebase/clientApp';
@@ -82,7 +83,76 @@ function firstNameOf(full: string): string {
   return (full || '').trim().split(/\s+/)[0] || full || 'them';
 }
 
+const BASE = process.env.NEXT_PUBLIC_BASE_URL ?? 'https://app.donatalk.com';
+
+// Per-profile SEO head. Rendered outside the `hydrated` gate so the tags are
+// present in the SSR HTML. Unavailable profiles (stub / soft-deleted / missing)
+// are marked noindex.
+function PitcherHead({ pitcher, uid }: { pitcher: Pitcher | null; uid: string }) {
+  const url = `${BASE}/pitcher/${uid}`;
+  const available = !!pitcher && pitcher.isSetUp !== false && !pitcher.deletedAt;
+
+  if (!available) {
+    return (
+      <Head>
+        <meta name="robots" content="noindex, follow" />
+        <link rel="canonical" href={url} />
+      </Head>
+    );
+  }
+
+  const name = pitcher.fullName || 'A DonaTalk pitcher';
+  const pitch = (pitcher.pitch || '').trim();
+  const description = (
+    pitch
+      ? `${name} on DonaTalk — ${pitch}`
+      : `Hear ${name}'s pitch on DonaTalk. They donate to your chosen non-profit for a meeting.`
+  ).slice(0, 155);
+  const title = `${name} — hear their pitch, fund your cause`;
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'ProfilePage',
+    url,
+    mainEntity: {
+      '@type': 'Person',
+      name,
+      ...(pitch ? { description: pitch } : {}),
+      url,
+    },
+  };
+
+  return (
+    <Head>
+      <title>{`${title} | DonaTalk`}</title>
+      <meta name="description" content={description} />
+      <link rel="canonical" href={url} />
+      <meta property="og:type" content="profile" />
+      <meta property="og:site_name" content="DonaTalk" />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:url" content={url} />
+      <meta property="og:image" content={`${BASE}/DonaTalk_icon_88x77.png`} />
+      <meta name="twitter:card" content="summary" />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+    </Head>
+  );
+}
+
 export default function PitcherPage({ pitcher, uid }: { pitcher: Pitcher | null; uid: string }) {
+  return (
+    <>
+      <PitcherHead pitcher={pitcher} uid={uid} />
+      <PitcherPageBody pitcher={pitcher} uid={uid} />
+    </>
+  );
+}
+
+function PitcherPageBody({ pitcher, uid }: { pitcher: Pitcher | null; uid: string }) {
   const [hydrated, setHydrated] = useState(false);
   const [user, setUser] = useState<User | null>(null);
   const [authResolved, setAuthResolved] = useState(false);


### PR DESCRIPTION
Executes **KR2-2a** (app SEO foundation) + **KR2-1** (keyword strategy).

## Why
The app currently ships **no** robots.txt, sitemap, OG tags, or per-profile metadata — GSC shows zero non-branded discovery. This is pure-upside foundation that unblocks measurement.

## App changes (no money/auth/email surfaces touched)
- **`app/robots.ts`** — allow public pages; disallow `/admin`, `/api/`, and auth-gated dashboards/money flows; link the sitemap. (Careful: disallows specific sub-paths, never the bare `/pitcher`/`/listener` prefix, so public profiles stay indexable.)
- **`app/sitemap.ts`** — `force-dynamic` sitemap (lazy Firebase import so `next build` never inits Firebase) covering static routes + all public (`isSetUp !== false && !deletedAt`) listener/pitcher profiles.
- **`app/layout.tsx`** — `metadataBase`, title template, Open Graph + Twitter cards, keywords, canonical; Organization + WebSite JSON-LD.
- **`pages/{listener,pitcher}/[uid].tsx`** — per-profile `<Head>` (title, description, canonical, OG/Twitter, ProfilePage/Person JSON-LD) rendered in **SSR** via a thin wrapper *outside* the `hydrated` gate; unavailable profiles (stub/soft-deleted/missing) marked `noindex`.

## Docs
- `docs/company/plans/seo-keyword-strategy.md` (KR2-1): 3 non-branded clusters (cold-email-alternatives / warm-introductions / donation-based-outreach), page-mapped. Volumes SERP-inferred — flagged to confirm with a keyword tool.
- Version → **0.12.0**, CHANGELOG, reference-doc headers, company-OS status.

## Verification (deploy gates)
- ✅ `npx tsc --noEmit` clean
- ✅ `npm run test` — **299/299 pass**
- ✅ `npm run build` — green; `/robots.txt` (static) + `/sitemap.xml` (dynamic) both emit

## Known follow-ups (not blockers)
- Profile page bodies render client-side (gated on `hydrated`); the SEO `<Head>` is SSR, but a fuller SSR of profile body content is a separate improvement.
- OG image is the existing logo; a dedicated 1200×630 / generated OG image is a nice-to-have.

## After merge
Vercel auto-deploys → post-deploy health probe (auto-rollback if critical paths break) → submit `app.donatalk.com/sitemap.xml` to Google Search Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)