### PR TITLE
ops: headless-run prerequisites (allowlist + runner cwd)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git *)",
+      "Bash(gh *)",
+      "Bash(npm *)",
+      "Bash(npx *)",
+      "Bash(node *)",
+      "Bash(curl *)",
+      "PowerShell(git *)",
+      "PowerShell(gh *)",
+      "PowerShell(npm *)",
+      "PowerShell(npx *)",
+      "PowerShell(node *)",
+      "PowerShell(curl *)",
+      "Read",
+      "Edit",
+      "Write",
+      "Glob",
+      "Grep",
+      "WebFetch",
+      "WebSearch"
+    ]
+  }
+}

--- a/ops/run-routine.ps1
+++ b/ops/run-routine.ps1
@@ -53,8 +53,12 @@ try {
 # --- run the routine via claude -p ---
 $Prompt = Get-Content $PromptFile -Raw
 Write-Host "[$Stamp] Running routine '$Routine'..."
-$Output = & claude -p $Prompt --permission-mode acceptEdits 2>&1 | Tee-Object -FilePath $LogFile
-$Code = $LASTEXITCODE
+# Run claude from the repo root so it reads the company OS / repo as its cwd.
+Push-Location $RepoRoot
+try {
+  $Output = & claude -p $Prompt --permission-mode acceptEdits 2>&1 | Tee-Object -FilePath $LogFile
+  $Code = $LASTEXITCODE
+} finally { Pop-Location }
 
 if ($Code -ne 0) {
   $class = Get-RootCause ($Output -join "`n")


### PR DESCRIPTION
Permission allowlist for unattended `claude -p` + run the routine from the repo root. Prereq for relocating the ops host to D:\dev\donatalk_ws.