### PR TITLE
ops: harden runner for unattended loop (branch hygiene + deterministic metrics)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,8 @@
       "Bash(npx *)",
       "Bash(node *)",
       "Bash(curl *)",
+      "Bash(powershell *)",
+      "Bash(pwsh *)",
       "PowerShell(git *)",
       "PowerShell(gh *)",
       "PowerShell(npm *)",

--- a/ops/routines/daily-ops.md
+++ b/ops/routines/daily-ops.md
@@ -1,18 +1,26 @@
 You are the autonomous CEO of DonaTalk, running the **daily-ops** routine
 (every 3 hours). You have zero memory of prior runs — the repo is your memory.
 
+The runner has already, before you started: reset the repo to a clean `main`,
+run `check-site.ps1` (probe), and run `get-metrics.ps1` (metric rows). So you are
+on `main` with health/metrics already collected this run.
+
 ## Do this, in order
 1. **Read the company OS** (this is mandatory, in order):
    `docs/company/CHARTER.md` → `OKR.md` → `STRATEGY.md` → `BACKLOG.md`
    → `DECISIONS.md` → `METRICS.md`. Obey the Charter's escalation gates (§3b).
-2. **Health + metrics:** run `ops/check-site.ps1` and `ops/get-metrics.ps1`.
-   Confirm rows were appended to `docs/company/metrics/*.csv` (KR1-2 requires
-   100% coverage — if a collector is stubbed/blocked, append a row noting that).
+2. **Verify health + metrics** (the runner already collected them — KR1-2 is
+   runner-guaranteed): read the newest `ops/logs/site-check-*.json` and the tails
+   of `docs/company/metrics/*.csv`, and interpret them. Only re-run a collector if
+   an artifact is missing. Never fabricate numbers.
 3. **Advance the top unblocked Backlog item** toward the current OKRs. Prefer
    the lowest-numbered ⬜/🟡 item that is not 🔴 BLOCKED.
+   - **Always do code/doc work on a new branch** (the runner resets `main` each
+     run, so committing to `main` locally would be discarded). Push the branch.
    - If it touches a **money / auth / email / secret** surface (Charter §3b):
-     do NOT self-merge — open a PR and write `ops/logs/ALERT-*`.
-   - Otherwise you may commit and (if it passes Deploy Gates §4) deploy.
+     open a PR and write `ops/logs/ALERT-*` — do NOT self-merge.
+   - Otherwise you may open a PR and merge it, or run `ops/deploy-web.ps1` for a
+     gated direct deploy (gates → deploy → post-deploy probe → auto-rollback).
 4. **Record:** update `BACKLOG.md` status, append to `DECISIONS.md` if you made a
    consequential call, and write/update today's brief at
    `docs/company/reports/YYYY-MM-DD-daily.md` (OKR progress, health snapshot,

--- a/ops/run-routine.ps1
+++ b/ops/run-routine.ps1
@@ -43,12 +43,25 @@ function Get-RootCause([string]$Output) {
 
 if (-not (Test-Path $PromptFile)) { Write-Alert 'config-error' "Missing prompt: $PromptFile"; exit 2 }
 
-# --- git-write pre-flight: confirm we can reach origin (read-only check) ---
+# --- git pre-flight: reach origin, then start clean on latest main ---
+# A prior run may leave a feature branch checked out; always reset to origin/main
+# so each run begins from a known, current state.
 Push-Location $RepoRoot
 try {
   git fetch --quiet origin 2>&1 | Out-Null
   if ($LASTEXITCODE -ne 0) { Write-Alert 'git-write-failure' 'git fetch origin failed in pre-flight.'; exit 3 }
+  git checkout main --quiet 2>&1 | Out-Null
+  if ($LASTEXITCODE -ne 0) { Write-Alert 'git-write-failure' 'git checkout main failed (dirty tree?).'; exit 3 }
+  git reset --hard origin/main --quiet 2>&1 | Out-Null
 } finally { Pop-Location }
+
+# --- deterministic health + metrics (KR1-2 / KR1-4), runner-owned so coverage
+#     does not depend on the agent's tool permissions ---
+Push-Location $RepoRoot
+try {
+  & (Join-Path $PSScriptRoot 'check-site.ps1')  2>&1 | Out-Null; Write-Host "[$Stamp] probe collected."
+  & (Join-Path $PSScriptRoot 'get-metrics.ps1') 2>&1 | Out-Null; Write-Host "[$Stamp] metrics collected."
+} catch { Write-Host "[$Stamp] health/metrics collection warning: $($_.Exception.Message)" } finally { Pop-Location }
 
 # --- run the routine via claude -p ---
 $Prompt = Get-Content $PromptFile -Raw


### PR DESCRIPTION
Fixes from the first live daily-ops run: reset to clean main each run; runner collects health+metrics deterministically (removes the allowlist-gap KR1-1 risk); allow powershell in allowlist; daily-ops prompt updated for branch workflow.