### PR TITLE
ops: fix PS5.1 parse break + verify Charter money-gate (KR1-3/1-4)

### DIFF
--- a/docs/company/BACKLOG.md
+++ b/docs/company/BACKLOG.md
@@ -2,7 +2,7 @@
 
 > Ordered work queue. Each scheduled run advances the top **unblocked** item.
 > Status: ⬜ todo · 🟡 in progress · ✅ done · 🔴 BLOCKED
-> Last updated: 2026-07-09
+> Last updated: 2026-07-09 (run 4)
 
 ## Now (Obj 1 — the machine)
 | # | Item | KR | Status |
@@ -11,9 +11,9 @@
 | 2 | Scaffold `ops/` runner + routines + failure classifier + alerting | 1-1 | ✅ done (runner + 3 routines + classifier + allowlist PR #23) |
 | 3 | `ops/check-site.ps1` synthetic probe (home/`/listeners`/signup) + self-clean | 1-4 | ✅ done (probing green each run) |
 | 4 | `ops/get-metrics.ps1` — append rows to awareness/funnel/ops-health logs | 1-2 | ✅ done (100% coverage; credentialed sources stubbed n/a) |
-| 5 | Deploy gate + auto-rollback wrapper (`ops/deploy-web.ps1`) | 1-4 | 🟡 built 2026-07-09 (PR open); live rollback test pending a real deploy |
+| 5 | Deploy gate + auto-rollback wrapper (`ops/deploy-web.ps1`) | 1-4 | 🟡 built 2026-07-09; **fixed same day — was parse-broken under Windows PowerShell 5.1 (non-ASCII `§`/`—`, no BOM); all `ops/*.ps1` now ASCII + parse-verified.** Gate-3 (§3b) path proven live; live rollback test still pending a real failing deploy |
 | 6 | Register Windows Task Scheduler jobs (3h ops, daily research, weekly report, 6h probe) | 1-1 | 🔴 needs scheduler host |
-| 7 | Charter dry-run: trip a money-gate, confirm PR+ALERT path works | 1-3 | ⬜ |
+| 7 | Charter dry-run: trip a money-gate, confirm PR+ALERT path works | 1-3 | ✅ done 2026-07-09 — dry-run touched `lib/updateFunds.ts`; `deploy-web.ps1` exited 10 + wrote `ALERT-deploy-20260709T134414Z.txt`, no deploy; money edit reverted, never merged |
 
 ## Now (Obj 2 — visibility, no blockers)
 | # | Item | KR | Status |

--- a/docs/company/DECISIONS.md
+++ b/docs/company/DECISIONS.md
@@ -4,6 +4,9 @@ Important, durable decisions only — the ones that shape how the business runs.
 Operational narrative → `reports/`. Machine logs/alerts → `ops/logs/`.
 Format: `date — decision — one-line rationale`. Newest first.
 
+## 2026-07-09
+- Ops scripts are pure-ASCII (no `§`/`—`), not UTF-8-with-typography. — Windows PowerShell 5.1 (the scheduler host shell) reads BOM-less `.ps1` as ANSI and mis-decodes non-ASCII; it had silently broken `deploy-web.ps1` parsing. ASCII is portable across PS 5.1/7 with no BOM dependency.
+
 ## 2026-07-08
 - Board-review docs stay concise; DECISIONS holds only important decisions. — fast board review.
 - Autonomy: full auto-deploy (gated: tests+tsc pass, money/auth/email excluded, auto-rollback), both SEO surfaces, fully autonomous posting (supervised ramp + kill-switch). — board's velocity call; rails protect solvency and brand.

--- a/docs/company/OKR.md
+++ b/docs/company/OKR.md
@@ -9,8 +9,8 @@
 |----|--------|---------|--------|
 | **1-1** | ≥16 consecutive scheduled runs (3h + daily) over 48h complete with success exit, **zero unhandled failures**; every failure auto-classified to an `ALERT-*` file. | `ops/logs/` run history | ⬜ not started |
 | **1-2** | `METRICS.md` catalog exists; **100%** of runs append a timestamped row to awareness / funnel / ops-health logs. | metric CSVs | ⬜ not started |
-| **1-3** | Governance Charter in force with machine-enforced escalation gates; verified by a dry-run that trips a gate. | `CHARTER.md` + dry-run log | 🟡 ratified 2026-07-09 (PR #18); dry-run pending |
-| **1-4** | Synthetic health probe on app.donatalk.com critical paths every 6h, self-cleaning, auto-rollback wired. | `ops/check-site.ps1` + probe log | 🟡 probe live + green each run (3 paths, 200+marker); auto-rollback wrapper `ops/deploy-web.ps1` built 2026-07-09 (PR open) — 6h cadence needs scheduler host (item 6); live rollback untested (no failing deploy yet) |
+| **1-3** | Governance Charter in force with machine-enforced escalation gates; verified by a dry-run that trips a gate. | `CHARTER.md` + dry-run log | ✅ verified 2026-07-09: money-gate dry-run tripped the §3b scanner in `deploy-web.ps1` — touched `lib/updateFunds.ts`, wrapper exited 10, wrote `ALERT-deploy-20260709T134414Z.txt`, did NOT deploy (change routed to PR, never merged; money edit reverted) |
+| **1-4** | Synthetic health probe on app.donatalk.com critical paths every 6h, self-cleaning, auto-rollback wired. | `ops/check-site.ps1` + probe log | 🟡 probe live + green each run (3 paths, 200+marker); auto-rollback wrapper `ops/deploy-web.ps1` built 2026-07-09. **Fixed 2026-07-09: the wrapper (and all `ops/*.ps1`) failed to parse under Windows PowerShell 5.1 — non-ASCII `§`/`—` with no BOM broke `deploy-web.ps1:62`; would have been dead-on-arrival on the scheduler host. Now pure-ASCII + PS5.1 parse-verified; gate-trip path proven live.** 6h cadence still needs scheduler host (item 6); live rollback (failing-deploy path) untested |
 
 ## Obj 2 — Increase DonaTalk's search visibility
 

--- a/docs/company/reports/2026-07-09-daily.md
+++ b/docs/company/reports/2026-07-09-daily.md
@@ -55,3 +55,27 @@
 - Live auto-rollback path is built but **untested end-to-end** (no failing deploy has occurred). Item 7 (Charter money-gate dry-run) remains the next unblocked machine item.
 
 **Alerts:** none this run.
+
+---
+
+## Run 4 — 20260709T1344Z (daily-ops, every-3h)
+
+**Headline:** KR1-3 verified via money-gate dry-run — which surfaced and fixed a latent bug that made the deploy/auto-rollback wrapper (and all `ops/*.ps1`) fail to parse on the scheduler host's shell.
+
+**Context:** Interactive run. Also verified the repo migration (OneDrive → `D:\dev\donatalk_ws\donatalk`) is clean: no stale absolute-path refs in tracked source, git remote/worktree state intact, `npx tsc --noEmit` green in the new location. One orphaned artifact flagged: `.claude/worktrees/company-os-scaffold/` is a leftover copy from the old OneDrive path (its `.git` points at the dead `C:\...\OneDrive\...` path, no longer a registered worktree) — safe to delete, left untouched pending confirmation.
+
+**Health snapshot**
+- Synthetic probe: **green** — newest artifact `site-check-20260709T131900Z.json`, `/`, `/listeners`, `/login` all 200. ops-health log carries this window's `probe:success` rows; awareness `A1–A6 n/a` (creds pending) / `A7=0` (empty ledger); funnel `F1–F4/R1 n/a` (Firebase Admin pending). No fabricated numbers.
+
+**What advanced**
+- **Backlog #7 → ✅ (KR1-3 verified):** Ran the Charter money-gate dry-run. Added a transient no-op marker to `lib/updateFunds.ts` (a §3b money surface) and ran `ops/deploy-web.ps1 -SkipDeploy`. The wrapper's §3b scanner caught it, **exited 10, wrote `ALERT-deploy-20260709T134414Z.txt`, and did NOT deploy** — proving the machine-enforced escalation gate (gated surface → PR + ALERT, never auto-ship). Handled compliantly: money edit **reverted** (no money logic changed), change **never merged**.
+- **Backlog #5 bug fixed (KR1-4):** The dry-run's first attempt failed with a PowerShell *parse* error — `deploy-web.ps1:62` had `§`/`—` (U+00A7/U+2014) inside a double-quoted string, and BOM-less `.ps1` files are read as ANSI by **Windows PowerShell 5.1** (the scheduler-host shell per `ops/README.md`), corrupting the string and breaking parsing. All four `ops/*.ps1` had the same non-ASCII content. **Fix:** replaced `§`→`Sec `, `—`→`-` across all four scripts (CRLF preserved); re-verified each parses via `PSParser::Tokenize`. Without this, the deploy/auto-rollback wrapper would have been dead-on-arrival on the host — KR1-4's safety net silently absent.
+
+**Shipping**
+- Non-gated ops-tooling + governance-doc change → **PR** (matches #22/#23/#25 ops cadence). No app/test source touched → no version bump (per `.ai-instructions.md`, ops/docs only). `ops/*.ps1` parse-verified; app tree unchanged at green v0.12.0.
+
+**What's blocked**
+- Scheduler host (item 6), approved posting accounts (item 15), WordPress App Password rotation — unchanged, board-side.
+- Live auto-rollback (failing-deploy) path still untested end-to-end; gate-3 (§3b) path now proven live.
+
+**Alerts:** `ALERT-deploy-20260709T134414Z.txt` was written **by design** (the dry-run) — not a real incident. No unplanned alerts.

--- a/ops/check-site.ps1
+++ b/ops/check-site.ps1
@@ -3,7 +3,7 @@
   Synthetic health probe for app.donatalk.com critical paths (KR1-4).
   Read-only: fetches public routes, asserts 200 + expected markers. Writes a
   JSON result to ops/logs and an ops-health-log row. NO test users created
-  (booking/signup are behind auth + PayPal — probing them live would touch
+  (booking/signup are behind auth + PayPal - probing them live would touch
   money-adjacent flows, which the Charter fences off). Extend with a disposable
   Firebase test user only once a non-prod path exists.
 .EXAMPLE

--- a/ops/deploy-web.ps1
+++ b/ops/deploy-web.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-  Deploy-gate + auto-rollback wrapper for app.donatalk.com (KR1-4, Charter §4).
+  Deploy-gate + auto-rollback wrapper for app.donatalk.com (KR1-4, Charter Sec 4).
 
   Enforces the four Deploy Gates before shipping to Vercel production, promotes
   the build, then runs the synthetic probe (check-site.ps1). If a critical path
@@ -30,11 +30,11 @@ New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
 function Write-DeployAlert([string]$Reason, [string]$Detail) {
   $f = Join-Path $LogDir "ALERT-deploy-$Stamp.txt"
   @"
-ALERT (deploy) — $Stamp
+ALERT (deploy) - $Stamp
 Reason: $Reason
 $Detail
 
-Charter §4 (Deploy Gates) / §8 (escalation). Board action may be required.
+Charter Sec 4 (Deploy Gates) / Sec 8 (escalation). Board action may be required.
 "@ | Set-Content -Encoding utf8 $f
   Write-Host "WROTE $f"
 }
@@ -47,10 +47,10 @@ function Add-DeployHealthRow([string]$H1, [string]$H4, [string]$Note) {
 
 Push-Location $RepoRoot
 try {
-  # ---- Gate 3 (run FIRST — cheapest, and the one that protects donor trust) ----
-  # If the pending diff touches any §3b-gated surface, this wrapper must NOT
-  # auto-deploy: those changes ship via PR + ALERT (Charter §3b). Over-matching
-  # here is intentional — "when in doubt, treat as gated."
+  # ---- Gate 3 (run FIRST - cheapest, and the one that protects donor trust) ----
+  # If the pending diff touches any Sec 3b-gated surface, this wrapper must NOT
+  # auto-deploy: those changes ship via PR + ALERT (Charter Sec 3b). Over-matching
+  # here is intentional - "when in doubt, treat as gated."
   $gated = '(lib/updateFunds|app/api/.*(order|checkout|complete-order)|credit_balance|reservedBalance|lib/mailer|send-.*-email|send-notification|adminAuth|meetingTokens|admin-?allowlist|middleware|rate-?limit)'
   $changed = @()
   $changed += (git diff --name-only origin/main...HEAD)  # committed vs origin
@@ -59,19 +59,19 @@ try {
   $changed = $changed | Where-Object { $_ } | Sort-Object -Unique
   $hits = $changed | Where-Object { $_ -match $gated }
   if ($hits) {
-    Write-DeployAlert 'gated-surface-touched' ("Diff touches §3b-gated files — must ship via PR, not auto-deploy:`n" + ($hits -join "`n"))
+    Write-DeployAlert 'gated-surface-touched' ("Diff touches Sec 3b-gated files - must ship via PR, not auto-deploy:`n" + ($hits -join "`n"))
     exit 10
   }
 
   # ---- Gate 1: tsc clean ----
   Write-Host "Gate 1/4: npx tsc --noEmit ..."
   npx tsc --noEmit
-  if ($LASTEXITCODE -ne 0) { Write-DeployAlert 'tsc-failed' 'npx tsc --noEmit reported errors — not shipping.'; exit 11 }
+  if ($LASTEXITCODE -ne 0) { Write-DeployAlert 'tsc-failed' 'npx tsc --noEmit reported errors - not shipping.'; exit 11 }
 
   # ---- Gate 2: tests pass (a red build never ships) ----
   Write-Host "Gate 2/4: npm run test ..."
   npm run test
-  if ($LASTEXITCODE -ne 0) { Write-DeployAlert 'tests-failed' 'npm run test failed — a red build never ships.'; exit 12 }
+  if ($LASTEXITCODE -ne 0) { Write-DeployAlert 'tests-failed' 'npm run test failed - a red build never ships.'; exit 12 }
 
   # ---- Gate 4: version bump + CHANGELOG (heuristic warning only) ----
   $verChanged = ($changed -contains 'package.json')
@@ -82,7 +82,7 @@ try {
   Write-Host "Deploy gates passed."
 
   if ($SkipDeploy) {
-    Write-Host "SkipDeploy set — probing current production only (no deploy)."
+    Write-Host "SkipDeploy set - probing current production only (no deploy)."
     & (Join-Path $PSScriptRoot 'check-site.ps1')
     exit $LASTEXITCODE
   }
@@ -108,7 +108,7 @@ try {
   $probe = $LASTEXITCODE
 
   if ($probe -ne 0) {
-    Write-Host "POST-DEPLOY PROBE FAILED — auto-rolling-back."
+    Write-Host "POST-DEPLOY PROBE FAILED - auto-rolling-back."
     if ($prev) { npx vercel rollback $prev --yes } else { npx vercel rollback --yes }
     $rb = $LASTEXITCODE
     & (Join-Path $PSScriptRoot 'check-site.ps1')   # confirm rollback restored health
@@ -118,7 +118,7 @@ try {
     exit 14
   }
 
-  Write-Host "Deploy healthy — production probe green."
+  Write-Host "Deploy healthy - production probe green."
   Add-DeployHealthRow 'success' 'no-rollback' 'deploy + post-deploy probe green'
   exit 0
 } finally { Pop-Location }

--- a/ops/get-metrics.ps1
+++ b/ops/get-metrics.ps1
@@ -1,7 +1,7 @@
 <#
 .SYNOPSIS
   Collect metrics and append rows to docs/company/metrics/*.csv (KR1-2).
-  Sources that need credentials are STUBBED with an explicit "n/a — needs X"
+  Sources that need credentials are STUBBED with an explicit "n/a - needs X"
   marker so coverage stays 100% (a logged "no data" row still proves the run
   measured). Wire real sources as the board provisions access.
 
@@ -18,18 +18,18 @@ $Root       = Split-Path -Parent $PSScriptRoot
 $MetricsDir = Join-Path $Root 'docs/company/metrics'
 $Date       = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd')
 
-# A7 — count do-follow backlinks from the ledger (this we can do today)
+# A7 - count do-follow backlinks from the ledger (this we can do today)
 $ledger = Join-Path $MetricsDir 'backlink-ledger.md'
 $a7 = 0
 if (Test-Path $ledger) {
   $a7 = (Select-String -Path $ledger -Pattern '\|\s*yes\s*\|' -AllMatches).Count
 }
 
-# Awareness row — A1..A6 pending credentials, A7 live
+# Awareness row - A1..A6 pending credentials, A7 live
 Add-Content -Encoding utf8 (Join-Path $MetricsDir 'awareness-log.csv') `
   "$Date,n/a,n/a,n/a,n/a,n/a,n/a,$a7,A1-A6 pending GSC/GA4 creds; A7 from ledger"
 
-# Funnel row — pending Firebase Admin read
+# Funnel row - pending Firebase Admin read
 Add-Content -Encoding utf8 (Join-Path $MetricsDir 'funnel-log.csv') `
   "$Date,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account"
 

--- a/ops/run-routine.ps1
+++ b/ops/run-routine.ps1
@@ -25,10 +25,10 @@ New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
 function Write-Alert([string]$Class, [string]$Detail) {
   $f = Join-Path $LogDir "ALERT-$Class-$Stamp.txt"
   @"
-ALERT ($Class) — routine=$Routine — $Stamp
+ALERT ($Class) - routine=$Routine - $Stamp
 $Detail
 
-Board action may be required. See docs/company/CHARTER.md §8 (escalation).
+Board action may be required. See docs/company/CHARTER.md Sec 8 (escalation).
 "@ | Set-Content -Encoding utf8 $f
   Write-Host "WROTE $f"
 }


### PR DESCRIPTION
## What
Autonomous daily-ops run 4 (2026-07-09). Two Obj-1 outcomes:

### 1. KR1-3 verified — Charter money-gate dry-run (Backlog #7)
Touched `lib/updateFunds.ts` (a §3b money surface) and ran `ops/deploy-web.ps1 -SkipDeploy`. The wrapper's §3b scanner:
- **exited 10**, **wrote `ALERT-deploy-20260709T134414Z.txt`**, and **did not deploy** — routing the gated change to PR+ALERT exactly as the Charter requires.
- Handled compliantly: the money edit was **reverted** (no money logic changed) and **never merged**. This PR contains no money-surface change.

### 2. KR1-4 bug fixed — ops scripts were parse-broken on the scheduler host
The dry-run's first attempt failed with a PowerShell **parse error**: `deploy-web.ps1:62` had `§`/`—` (U+00A7/U+2014) inside a double-quoted string, and BOM-less `.ps1` files are read as ANSI by **Windows PowerShell 5.1** (the scheduler-host shell per `ops/README.md`), corrupting the string. All four `ops/*.ps1` shared the same non-ASCII content — the deploy/auto-rollback wrapper would have been **dead-on-arrival** on the host, KR1-4's safety net silently absent.

**Fix:** `§`→`Sec `, `—`→`-` across all four scripts (CRLF preserved). Each re-verified via `PSParser::Tokenize`. Also decided (DECISIONS): ops scripts stay pure-ASCII — portable across PS 5.1/7 with no BOM dependency.

## Also
Verified the OneDrive→`D:\dev\donatalk_ws\donatalk` migration is clean (no stale absolute paths in tracked source, git remote/worktree intact, `tsc --noEmit` green in new location). Flagged one orphan for board: `.claude/worktrees/company-os-scaffold/` is a leftover copy from the old OneDrive path — safe to delete.

## Scope / gates
- Ops-tooling + governance docs only; no app/test source touched → no version bump.
- `ops/*.ps1` parse-verified; app tree unchanged at green v0.12.0.
- Not a §3b-gated change (money edit reverted, not included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)