### PR TITLE
content: flagship Cluster A "cold email alternatives" listicle (Obj-2)

### DIFF
--- a/docs/company/BACKLOG.md
+++ b/docs/company/BACKLOG.md
@@ -2,7 +2,7 @@
 
 > Ordered work queue. Each scheduled run advances the top **unblocked** item.
 > Status: ⬜ todo · 🟡 in progress · ✅ done · 🔴 BLOCKED
-> Last updated: 2026-07-09 (run 5)
+> Last updated: 2026-07-09 (run 6)
 
 ## Now (Obj 1 — the machine)
 | # | Item | KR | Status |
@@ -30,6 +30,14 @@
 | 13 | GSC verified (both domains) + baseline pulled | ✅ done; app sitemap still to submit (item 8) |
 | 14 | WordPress credential (App Password, admin) stored in Vercel | ✅ done; build publish pipeline next |
 | 15 | Autonomous posting — supervised ramp (first 5 posts) | 🔴 needs approved accounts |
+
+## Now (Obj 2 — content engine)
+| # | Item | KR | Status |
+|---|------|----|--------|
+| 16 | Cluster A listicle — "cold email alternatives" (`donatalk.com/blog/`) | 2-1→2-3 | 🟡 drafted `docs/company/content/cold-email-alternatives.md` (publish-ready, brand-voice, Sec 6-truthful). **Publish blocked:** WP App Password pending rotation + publish pipeline (item 14) unbuilt |
+| 17 | Cluster B pillar + template — "how to get warm introductions" | 2-1→2-3 | ⬜ todo (next content piece) |
+| 18 | Cluster C explainer + app `/vs` page — "donation-based outreach" | 2-1→2-3 | ⬜ todo (app surface = fully autonomous/deployable) |
+| 14b | WordPress publish pipeline: markdown draft → WP REST draft post (reads creds from env) | 2-2 | ⬜ todo — **gate on WP App Password rotation first** |
 
 ## Follow-ups (unblocked, this cycle)
 - **Allowlist the ops scripts.** `claude -p --permission-mode acceptEdits` still enforces the

--- a/docs/company/content/README.md
+++ b/docs/company/content/README.md
@@ -1,0 +1,44 @@
+# DonaTalk — Content Staging
+
+> Publish-ready drafts for the two-surface content engine (Strategy pillar 3).
+> Each file is authored here, Board-reviewable in the repo, then published by the
+> WordPress publish pipeline (Backlog item 14) or hand-published, once the WP
+> Application Password is **rotated** (see `../BACKLOG.md` blockers).
+
+## Why drafts live here
+Writing content needs no credential and is fully in the CEO's autonomy (Charter
+Sec 3a, Content Rules Sec 6). Publishing to `donatalk.com` (WordPress) does — and
+that credential rode through chat and is pending rotation. So we **stage the
+asset now, publish when the pipeline + rotated credential are live.** Nothing
+here is public until explicitly published.
+
+## Front-matter convention
+Every draft starts with YAML the publish pipeline can read:
+
+```yaml
+---
+title: <SEO <title>, <=60 chars>
+slug: <url slug>
+surface: wordpress | app
+target_url: <intended live URL>
+cluster: A | B | C            # from plans/seo-keyword-strategy.md
+primary_keyword: <head term>
+secondary_keywords: [ ... ]
+meta_description: <=155 chars
+status: draft | ready | published
+author: DonaTalk (CEO agent)
+---
+```
+
+## Content rules (Charter Sec 6) — enforced on every piece
+- Truthful only. No invented metrics, fake testimonials, or non-profit
+  partnerships that don't exist. First-party product claims must match reality.
+- Claims about third-party tools stay accurate and non-defamatory — describe the
+  *category/approach* rather than asserting unverifiable product specifics.
+- Brand voice: warm, sincere, sales-professional-literate. Anchor to the one
+  line: **"What if every sales call also helped a non-profit?"**
+
+## Index
+| File | Cluster | Surface | Status |
+|------|---------|---------|--------|
+| `cold-email-alternatives.md` | A | WordPress | draft |

--- a/docs/company/content/cold-email-alternatives.md
+++ b/docs/company/content/cold-email-alternatives.md
@@ -1,0 +1,196 @@
+---
+title: "11 Cold Email Alternatives That Actually Get Replies (2026)"
+slug: cold-email-alternatives
+surface: wordpress
+target_url: https://donatalk.com/blog/cold-email-alternatives
+cluster: A
+primary_keyword: cold email alternatives
+secondary_keywords:
+  - alternatives to cold calling
+  - cold outreach alternatives
+  - what to do instead of cold email
+  - better ways to book B2B meetings
+  - fill pipeline without cold email
+meta_description: "Cold email averages a ~1% reply rate. Here are 11 alternatives that actually get B2B meetings booked in 2026 — from warm intros to donation-based outreach."
+status: draft
+author: DonaTalk (CEO agent)
+---
+
+# 11 Cold Email Alternatives That Actually Get Replies in 2026
+
+If you send cold email for a living, you already know the number that this whole
+article is really about: **about 1%.** That's the average response rate on a cold
+email in 2026. Send a hundred, hear back from one — and that one is often a "no."
+
+The problem isn't your subject line. It's the format. Cold email asks a stranger
+to give you their time before you've given them a single reason to. Every
+alternative below is really an answer to the same question: *how do you give the
+prospect a reason to say yes before you ask for the meeting?*
+
+Here are 11 ways to book B2B meetings without living and dying by the cold inbox —
+ranked roughly from "swap in today" to "rethink the whole motion."
+
+---
+
+## 1. Donation-based outreach (buy the meeting for a cause, not for yourself)
+
+Start here, because it's the newest idea on the list and the one that directly
+fixes the reason cold email fails: **there's nothing in it for the person on the
+other end.**
+
+Donation-based outreach flips that. Instead of asking a prospect to do you a
+favor, you offer them one. On [DonaTalk](https://donatalk.com), a sales rep (the
+**Pitcher**) commits a donation to a non-profit the prospect (the **Listener**)
+actually cares about, in exchange for a real, agreed-upon conversation. The
+prospect picks the cause. The meeting is warm by construction — they said yes on
+purpose, and a charity they support is better off for it.
+
+**What if every sales call you made also helped a non-profit?** That's the whole
+pitch. It's not a gimmick tacked onto outreach; the incentive *is* the outreach.
+
+- **Best for:** reps who want a genuinely warm, opt-in meeting and are happy to
+  put a small donation behind their request instead of a $50 gift card.
+- **Why it works:** it replaces "please give me your time" with "I'll give to a
+  cause you love for your time" — a reason to say yes that a cold email never has.
+- **The catch:** it's a different muscle than spray-and-pray volume. You're
+  trading quantity for meetings that start on good terms.
+
+DonaTalk charges a small fee (4.9%) on the committed donation — the rest goes to
+the cause. No gift-card awkwardness, no "is this even ethical" gray area: the
+value goes to charity, not to the prospect's pocket.
+
+## 2. Warm introductions and referrals
+
+The oldest alternative and still the best-converting one. A warm intro from a
+mutual connection borrows their trust, so you skip the "who are you?" phase
+entirely.
+
+- **Best for:** anyone with a network worth mining (and everyone's is bigger than
+  they think — check second-degree LinkedIn connections).
+- **Why it works:** referred prospects reply because someone they trust vouched
+  for you.
+- **The catch:** it doesn't scale on its own. You run out of warm intros fast,
+  which is exactly the gap donation-based outreach (#1) is built to fill —
+  manufacturing a warm reason to connect when you don't have a mutual friend.
+
+## 3. LinkedIn engagement (comment before you connect)
+
+Instead of cold-DMing, show up in a prospect's world first: thoughtfully comment
+on their posts for a week or two, then connect. By the time you reach out, you're
+a familiar name, not a stranger.
+
+- **Best for:** reps whose buyers are active on LinkedIn.
+- **Why it works:** repeated, useful exposure builds recognition before the ask.
+- **The catch:** it's slow and manual, and it only works if your comments add
+  something. "Great post!" is just cold email with extra steps.
+
+## 4. Referral and partner selling
+
+Formalize #2: build referral relationships with adjacent vendors, agencies, and
+consultants who already sell to your buyer. Their customer is your prospect.
+
+- **Best for:** teams with clear "who else sells to my ICP" partners.
+- **Why it works:** you inherit an existing, trusted relationship.
+- **The catch:** partnerships take time to build and need to be reciprocal to last.
+
+## 5. Video prospecting
+
+Swap the wall of text for a 30–60 second personalized video. Seeing a real human
+say your name and reference your company cuts through in a way plain text can't.
+
+- **Best for:** reps comfortable on camera, selling considered/higher-ACV deals.
+- **Why it works:** it's personal and rare, so it stands out.
+- **The catch:** it doesn't scale to hundreds a day, and a lazy video is worse
+  than no video.
+
+## 6. Community-led outreach
+
+Go where your buyers already gather — Slack groups, Discords, subreddits,
+industry forums — and be genuinely useful there for weeks before you ever pitch.
+Relationships formed in community convert far better than interruptions.
+
+- **Best for:** patient teams playing a long game in a defined niche.
+- **Why it works:** trust compounds; people buy from community members they know.
+- **The catch:** overt selling gets you removed. This is a contribution game
+  first, a pipeline game second.
+
+## 7. Event and webinar-based outreach
+
+Host or speak at a webinar, roundtable, or local meetup. Everyone who registers
+has raised their hand — following up with an attendee is a warm conversation, not
+a cold one.
+
+- **Best for:** teams that can produce something worth showing up for.
+- **Why it works:** attendance is intent; you reach out with shared context.
+- **The catch:** events are real work to fill, and no-shows are the norm.
+
+## 8. Intent-data outbound
+
+Instead of emailing everyone, use intent signals (job changes, funding, tech-stack
+shifts, content consumption) to reach out only when a prospect is likely in-market.
+Same channel as cold email — much better timing.
+
+- **Best for:** teams with the tooling to act on signals quickly.
+- **Why it works:** relevance and timing beat volume.
+- **The catch:** it's still cold at the moment of contact — the reply rate lifts,
+  but the "why should I care about *you*" problem remains.
+
+## 9. Direct mail and thoughtful gifting
+
+A physical package or handwritten note lands in an empty mailbox, not a flooded
+inbox. Used sparingly on high-value accounts, it's memorable.
+
+- **Best for:** ABM motions on a short list of dream accounts.
+- **Why it works:** scarcity and effort signal that you mean it.
+- **The catch:** cost per touch is high, and gifting can feel like a bribe — one
+  reason cause-based giving (#1) sidesteps the ick: the value goes to charity,
+  not to the buyer personally.
+
+## 10. Social selling and personal brand
+
+Build an audience by posting useful content consistently. Do it well and inbound
+starts to replace outbound — prospects come to you already sold on your expertise.
+
+- **Best for:** reps willing to invest months in content.
+- **Why it works:** authority attracts; warm inbound closes faster.
+- **The catch:** it's a long build with no pipeline on day one.
+
+## 11. Cold calling (done like it's 2026)
+
+Yes, the phone still works — but the modern version is research-heavy and
+low-volume: a handful of well-prepared calls a day to people you have a real
+reason to call, not a dialer blasting a purchased list.
+
+- **Best for:** reps whose buyers still answer the phone.
+- **Why it works:** a live human conversation can't be ignored like an email can.
+- **The catch:** rejection-heavy, and gatekeepers are real. Best paired with a
+  warm reason to be calling in the first place.
+
+---
+
+## So what should you actually do?
+
+Notice the pattern: **every alternative that outperforms cold email does so by
+manufacturing a reason to say yes before the ask.** Warm intros borrow trust.
+Community builds it over time. Video and events make it personal.
+
+Donation-based outreach (#1) is the most direct version of that idea — it puts a
+tangible good (a donation to a cause the prospect chose) on the table *as* the
+reason. You don't wait months for a personal brand or hope for a mutual
+connection; you offer the prospect something they value up front.
+
+If cold email's 1% is wearing you down, the fix isn't a better template. It's a
+better offer.
+
+**What if every sales call you made also helped a non-profit?**
+[See how DonaTalk works →](https://donatalk.com)
+
+---
+
+*Editorial note (staging): first-party claims (mechanism, 4.9% fee, Pitcher/
+Listener model, "prospect picks the cause") are accurate to the DonaTalk product.
+The ~1% cold email response figure is industry-cited and used in DonaTalk brand
+assets; confirm the current published source before go-live. Third-party
+approaches are described at the category level to stay truthful and
+non-defamatory per Charter Sec 6. Do not publish until the WordPress App Password
+is rotated (Backlog blocker).*

--- a/docs/company/metrics/awareness-log.csv
+++ b/docs/company/metrics/awareness-log.csv
@@ -3,3 +3,4 @@ date_utc,A1,A2,A3,A4,A5,A6,A7,note
 2026-07-09,364,,10,37,4,12.2,0,"GSC baseline 28d (donatalk.com domain prop, both surfaces); A1=GA4 90d active users; queries all branded"
 2026-07-09,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger
 2026-07-09,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger
+2026-07-09,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger

--- a/docs/company/metrics/funnel-log.csv
+++ b/docs/company/metrics/funnel-log.csv
@@ -3,3 +3,4 @@ date_utc,F1,F2,F3,F4,R1,note
 2026-07-09,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account
 2026-07-09,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account
 2026-07-09,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account
+2026-07-09,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account

--- a/docs/company/metrics/ops-health-log.csv
+++ b/docs/company/metrics/ops-health-log.csv
@@ -5,3 +5,5 @@ ts_utc,run_type,H1,H2,H3,H4,note
 20260709T132224Z,probe,success,none,pass,not-run,critical-path probe (daily-ops run; node headless helper)
 20260709T132237Z,probe,success,none,pass,not-run,critical-path probe
 20260709T162041Z,probe,success,none,pass,not-run,critical-path probe
+20260709T192040Z,probe,success,none,pass,not-run,critical-path probe
+20260709T192239Z,probe,success,none,pass,not-run,critical-path probe

--- a/docs/company/reports/2026-07-09-daily.md
+++ b/docs/company/reports/2026-07-09-daily.md
@@ -106,3 +106,66 @@
 - Ops-script allowlist for headless agent runs — still needs board/host (writing `.claude/settings*.json` is itself agent-gated).
 
 **Alerts:** none this run.
+
+---
+
+## Run 6 — 20260709T1920Z (daily-ops, every-3h)
+
+**Headline:** Obj-2 content engine kicked off — drafted the flagship Cluster A
+"cold email alternatives" listicle (the keyword strategy's #1-priority piece),
+staged publish-ready in the repo. Obj-1 machine work is at its autonomous ceiling,
+so this run pivots to the visibility objective's next unblocked step.
+
+**Health snapshot**
+- Synthetic probe: **green** — newest artifact `site-check-20260709T192040Z.json`,
+  `allOk:true`, `/`, `/listeners`, `/login` all 200.
+- Metrics coverage (KR1-2, runner-collected this run): ops-health
+  `20260709T192040Z,probe,success,none,pass` appended; awareness `A1-A6 n/a`
+  (GSC/GA4 creds pending) / `A7=0` (empty ledger); funnel `F1-F4/R1 n/a`
+  (Firebase Admin pending). No fabricated numbers.
+
+**What advanced (Obj 2)**
+- **Backlog #16 -> drafted:** wrote `docs/company/content/cold-email-alternatives.md`
+  — "11 Cold Email Alternatives That Actually Get Replies (2026)", the
+  keyword-strategy's top-priority Cluster A piece. Publish-ready: YAML front-matter
+  (title/slug/surface/cluster/keywords/meta-description) the future WP publish
+  pipeline can consume; DonaTalk featured as the differentiated #1 entry; anchored
+  to "What if every sales call also helped a non-profit?".
+- **Content Rules (Sec 6) honored:** first-party claims (Pitcher/Listener model,
+  prospect picks the cause, 4.9% fee) accurate to product; the ~1% cold-email
+  figure is industry-cited + already in DonaTalk brand assets (flagged to confirm
+  source pre-go-live); third-party tools described at the category/approach level
+  to stay truthful + non-defamatory. No invented metrics, testimonials, or
+  partnerships.
+- **Established content staging convention:** new `docs/company/content/` dir +
+  README — drafts authored/Board-reviewable in-repo, published only after the WP
+  credential is rotated + pipeline built. Added Backlog items 16/17/18 (pieces
+  A/B/C) + 14b (publish pipeline).
+
+**Why content, not more machine work:** Obj-1's remaining items are all deferred
+or board-blocked — item 5's live-fire rollback is deferred-by-design (needs a
+controlled human window), items 6 (scheduler host) + 15 (posting accounts) await
+the Board. Obj-2's next unblocked step is content execution (the explicit "Next"
+from the run-2 brief + `BACKLOG`). Writing content needs no credential (Charter
+Sec 3a), so it's fully in autonomy.
+
+**Why staged-not-published:** publishing to `donatalk.com` needs the WP App
+Password, which (a) rode through chat and is **pending rotation** (open board
+blocker) and (b) isn't in this headless env, and (c) the publish pipeline
+(item 14b) isn't built. Drafting the asset now is the safe, reversible advance
+that de-risks the publish step. Cluster C's app-surface page (item 18) is the
+fully-autonomous/deployable content next.
+
+**Shipping**
+- Non-gated docs-only change (new content draft + staging README + Backlog/report
+  updates) -> **PR** (matches the #22-#27 ops cadence; keeps main->Vercel
+  board-visible). No app/test source touched -> no version bump (per
+  `.ai-instructions.md`, docs-only). No Sec 3b gate tripped.
+
+**What's blocked**
+- Scheduler host (item 6), approved posting accounts (item 15), **WP App Password
+  rotation** (now also gates content publishing) — all unchanged, board-side.
+- True live-fire rollback test — deferred by design.
+- Ops-script allowlist for headless agent runs — still board/host-side.
+
+**Alerts:** none this run.

--- a/ops/logs/site-check-20260709T192040Z.json
+++ b/ops/logs/site-check-20260709T192040Z.json
@@ -1,0 +1,22 @@
+﻿{
+    "ts":  "20260709T192040Z",
+    "base":  "https://app.donatalk.com",
+    "allOk":  true,
+    "checks":  [
+                   {
+                       "path":  "/",
+                       "status":  200,
+                       "ok":  true
+                   },
+                   {
+                       "path":  "/listeners",
+                       "status":  200,
+                       "ok":  true
+                   },
+                   {
+                       "path":  "/login",
+                       "status":  200,
+                       "ok":  true
+                   }
+               ]
+}

--- a/ops/logs/site-check-20260709T192239Z.json
+++ b/ops/logs/site-check-20260709T192239Z.json
@@ -1,0 +1,22 @@
+﻿{
+    "ts":  "20260709T192239Z",
+    "base":  "https://app.donatalk.com",
+    "allOk":  true,
+    "checks":  [
+                   {
+                       "path":  "/",
+                       "status":  200,
+                       "ok":  true
+                   },
+                   {
+                       "path":  "/listeners",
+                       "status":  200,
+                       "ok":  true
+                   },
+                   {
+                       "path":  "/login",
+                       "status":  200,
+                       "ok":  true
+                   }
+               ]
+}


### PR DESCRIPTION
## What
Kicks off the two-surface **content engine** (Strategy pillar 3). Drafts the SEO keyword strategy's **#1-priority piece** — the Cluster A "cold email alternatives" listicle — as a **publish-ready staged asset**.

- `docs/company/content/cold-email-alternatives.md` — "11 Cold Email Alternatives That Actually Get Replies (2026)". YAML front-matter (title/slug/surface/cluster/keywords/meta-description) the future WP publish pipeline consumes. DonaTalk featured as the differentiated #1 entry; anchored to *"What if every sales call also helped a non-profit?"*.
- `docs/company/content/README.md` — new content-staging convention.
- `BACKLOG.md` — content-engine items 16/17/18 (pieces A/B/C) + 14b (publish pipeline); #16 → drafted.
- `reports/2026-07-09-daily.md` — Run 6 brief.
- `metrics/*.csv` + `ops/logs/site-check-*.json` — this run's runner-collected probe (green) + awareness/funnel rows (KR1-2; `n/a` where creds pending).

## Charter compliance
- **Not published.** Publishing to donatalk.com needs the WP App Password, which is **pending rotation** (open board blocker) — drafting the asset is the safe, autonomous advance (Charter §3a, Content Rules §6).
- **§6-truthful:** first-party claims (Pitcher/Listener model, prospect picks the cause, 4.9% fee) accurate to product; ~1% cold-email figure is industry-cited + already in brand assets (flagged to confirm pre-go-live); third-party tools described at category level (non-defamatory). No invented metrics/testimonials/partnerships.
- No §3b-gated surface. Docs-only, no app/test source → no version bump.

## Why this item
Obj-1 machine work is at its autonomous ceiling (item 5 live-fire deferred; items 6/15 board-blocked). Obj-2's next unblocked step is content execution — the explicit "Next" from prior briefs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)