### PR TITLE
feat(seo): /vs donation-based-outreach comparison page (v0.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to DonaTalk are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [SemVer](https://semver.org/).
 
+## [0.13.0] - 2026-07-09
+
+### Added (SEO content — Cluster C)
+- `app/vs/page.tsx` — category-defining comparison page (`/vs`): "Donation-based outreach vs. cold email vs. paid gifting." Static server component with a comparison table, differentiators, how-it-works steps, and an FAQ. Includes WebPage + BreadcrumbList + FAQPage JSON-LD and full metadata (title/description/canonical/OG/Twitter). Compares approaches at the category level (no named competitors) per Charter Sec 6; first-party claims (donation-to-book, listener picks the cause, 4.9% fee, decline = no charge) mirror the live product.
+- `/vs` added to `app/sitemap.ts` static routes (priority 0.7, monthly).
+
 ## [0.12.0] - 2026-07-09
 
 ### Added (SEO foundation)

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -33,6 +33,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const staticRoutes: MetadataRoute.Sitemap = [
     { url: `${BASE}/`, lastModified: now, changeFrequency: 'daily', priority: 1 },
     { url: `${BASE}/listeners`, lastModified: now, changeFrequency: 'daily', priority: 0.9 },
+    { url: `${BASE}/vs`, lastModified: now, changeFrequency: 'monthly', priority: 0.7 },
     { url: `${BASE}/pitcher/signup`, lastModified: now, changeFrequency: 'monthly', priority: 0.6 },
     { url: `${BASE}/listener/signup`, lastModified: now, changeFrequency: 'monthly', priority: 0.6 },
     { url: `${BASE}/login`, lastModified: now, changeFrequency: 'monthly', priority: 0.3 },

--- a/app/vs/page.tsx
+++ b/app/vs/page.tsx
@@ -1,0 +1,423 @@
+// app/vs/page.tsx
+//
+// Cluster C ("donation-based outreach") category-defining comparison page.
+// Static server component — no data reads, safe to prerender. Compares three
+// *approaches* (cold email, paid gifting, donation-based outreach) at the
+// category level; it never names or disparages a specific competitor product,
+// per the Charter Sec 6 content rules (truthful, non-defamatory). First-party
+// claims (donation-to-book, listener picks the cause, 4.9% fee, decline = no
+// charge) mirror the live product.
+
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import { styled } from '@/styles/stitches.config';
+import PageWrapper from '@/components/layout/PageWrapper';
+import { PageHeading, PageSubheading, PrimaryCTA, SecondaryHint } from '@/components/ui/profileCards';
+
+const BASE = process.env.NEXT_PUBLIC_BASE_URL ?? 'https://app.donatalk.com';
+
+const META_DESCRIPTION =
+  'Donation-based outreach vs. cold email vs. paid gifting: how DonaTalk earns a warm meeting by funding a cause the recipient chooses — and why that beats a cold pitch or a gift card.';
+
+export const metadata: Metadata = {
+  title: 'Donation-Based Outreach vs. Cold Email',
+  description: META_DESCRIPTION,
+  keywords: [
+    'donation-based outreach',
+    'cold email alternative',
+    'warm introductions',
+    'book a meeting for charity',
+    'charitable sales outreach',
+    'paid gifting alternative',
+  ],
+  alternates: { canonical: '/vs' },
+  openGraph: {
+    type: 'article',
+    url: `${BASE}/vs`,
+    title: 'Donation-Based Outreach vs. Cold Email vs. Paid Gifting',
+    description: META_DESCRIPTION,
+    images: [{ url: '/logo%20horizontal%20with%20text.png', alt: 'DonaTalk' }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Donation-Based Outreach vs. Cold Email vs. Paid Gifting',
+    description: META_DESCRIPTION,
+    images: ['/logo%20horizontal%20with%20text.png'],
+  },
+  robots: { index: true, follow: true },
+};
+
+/* ---------------------------------------------------------------- content */
+
+type Approach = 'cold' | 'gifting' | 'donation';
+
+const COLUMNS: { key: Approach; label: string; highlight?: boolean }[] = [
+  { key: 'cold', label: 'Cold email / cold call' },
+  { key: 'gifting', label: 'Paid gifting' },
+  { key: 'donation', label: 'Donation-based outreach', highlight: true },
+];
+
+const ROWS: { dimension: string; cells: Record<Approach, string> }[] = [
+  {
+    dimension: 'What you send',
+    cells: {
+      cold: 'A pitch to someone who never asked to hear from you.',
+      gifting: 'A gift card, swag, or lunch — a personal perk for the recipient.',
+      donation: 'A donation to a non-profit the recipient chooses.',
+    },
+  },
+  {
+    dimension: 'Who benefits',
+    cells: {
+      cold: 'Only you, if it lands. Ignored messages help no one.',
+      gifting: 'The recipient personally — which can feel transactional.',
+      donation: 'A cause the recipient cares about — the reason they say yes.',
+    },
+  },
+  {
+    dimension: 'Reply dynamic',
+    cells: {
+      cold: 'Widely reported to sit near a 1% reply rate.',
+      gifting: 'Better than cold, but can read as a bribe and trip gifting policies.',
+      donation: 'An opt-in, warm conversation that starts on goodwill.',
+    },
+  },
+  {
+    dimension: 'What it costs you',
+    cells: {
+      cold: 'Your time plus outreach tooling — paid whether or not anyone replies.',
+      gifting: 'The full cost of the gift, spent up front regardless of the outcome.',
+      donation: 'A donation you set (from $10). Declined? You pay nothing.',
+    },
+  },
+  {
+    dimension: 'Effect on your brand',
+    cells: {
+      cold: 'Easily dismissed as spam; erodes trust at scale.',
+      gifting: 'Can feel like buying attention.',
+      donation: 'Aligns your outreach with generosity — authenticity is the point.',
+    },
+  },
+];
+
+const DIFFERENTIATORS: { icon: string; title: string; body: string }[] = [
+  {
+    icon: '🎯',
+    title: 'The incentive points outward',
+    body:
+      "A gift rewards the person; a donation rewards a cause they already believe in. That shifts the ask from “what's in it for me” to “what can we do together.”",
+  },
+  {
+    icon: '🤝',
+    title: 'It starts warm, not cold',
+    body:
+      'The recipient opts in by picking who gets the donation. By the time you talk, the conversation is invited — not interrupted.',
+  },
+  {
+    icon: '💸',
+    title: 'You only pay for a real yes',
+    body:
+      'The donation is committed when a listener accepts. If they decline, nothing is charged — so budget follows outcomes, not sent volume.',
+  },
+];
+
+const STEPS: string[] = [
+  'Find a person on DonaTalk and a cause they support that you want to back.',
+  'Commit a donation (from $10) to request 15 minutes of their time.',
+  'They accept → their chosen charity gets funded; they decline → you pay nothing.',
+];
+
+const FAQ: { q: string; a: string }[] = [
+  {
+    q: 'What is donation-based outreach?',
+    a: "Donation-based outreach is a way to earn a business conversation by committing a charitable donation instead of sending a cold pitch. On DonaTalk, a pitcher donates to a non-profit the recipient chooses in exchange for a short, opt-in meeting.",
+  },
+  {
+    q: 'How is it different from cold email?',
+    a: 'Cold email interrupts a stranger and is widely reported to sit near a 1% reply rate. Donation-based outreach gives the recipient a reason to say yes — funding a cause they care about — so the conversation starts warm and invited rather than unsolicited.',
+  },
+  {
+    q: 'Is this just paid gifting with extra steps?',
+    a: "No. Paid gifting rewards the recipient personally, which can feel transactional and may conflict with corporate gifting policies. A donation goes to a non-profit the recipient selects, so the value lands on a cause rather than a person.",
+  },
+  {
+    q: 'What does it cost, and what if the meeting is declined?',
+    a: 'You set the donation amount (from $10). DonaTalk charges a 4.9% fee on committed donations. If the recipient declines, nothing is charged — you only pay when a meeting is accepted.',
+  },
+];
+
+/* ------------------------------------------------------------------- JSON-LD */
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'WebPage',
+      '@id': `${BASE}/vs#webpage`,
+      url: `${BASE}/vs`,
+      name: 'Donation-Based Outreach vs. Cold Email vs. Paid Gifting',
+      description: META_DESCRIPTION,
+      isPartOf: { '@id': `${BASE}/#website` },
+      breadcrumb: { '@id': `${BASE}/vs#breadcrumb` },
+    },
+    {
+      '@type': 'BreadcrumbList',
+      '@id': `${BASE}/vs#breadcrumb`,
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'DonaTalk', item: BASE },
+        { '@type': 'ListItem', position: 2, name: 'Donation-based outreach vs. cold email', item: `${BASE}/vs` },
+      ],
+    },
+    {
+      '@type': 'FAQPage',
+      '@id': `${BASE}/vs#faq`,
+      mainEntity: FAQ.map((f) => ({
+        '@type': 'Question',
+        name: f.q,
+        acceptedAnswer: { '@type': 'Answer', text: f.a },
+      })),
+    },
+  ],
+};
+
+/* -------------------------------------------------------------------- styles */
+
+const Container = styled('div', {
+  width: '100%',
+  maxWidth: '860px',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  padding: '0 $md',
+});
+
+const Lede = styled('p', {
+  width: '100%',
+  maxWidth: '680px',
+  margin: '$sm 0 0',
+  fontSize: '$md',
+  lineHeight: 1.6,
+  color: '$dark',
+  textAlign: 'center',
+  '& strong': { color: '$heart' },
+});
+
+const SectionHeading = styled('h2', {
+  width: '100%',
+  maxWidth: '680px',
+  margin: '$lg 0 $sm',
+  fontSize: '$xl',
+  fontWeight: 700,
+  color: '$dark',
+  textAlign: 'center',
+});
+
+const TableScroll = styled('div', {
+  width: '100%',
+  marginTop: '$md',
+  overflowX: 'auto',
+  borderRadius: '$md',
+  border: '1px solid #e8eaec',
+});
+
+const Table = styled('table', {
+  width: '100%',
+  minWidth: '640px',
+  borderCollapse: 'collapse',
+  fontSize: '14px',
+  backgroundColor: '$white',
+});
+
+const Th = styled('th', {
+  padding: '12px 14px',
+  textAlign: 'left',
+  fontWeight: 700,
+  color: '$dark',
+  backgroundColor: '#f8f6f4',
+  borderBottom: '1px solid #e8eaec',
+  verticalAlign: 'bottom',
+  variants: {
+    highlight: { true: { backgroundColor: '#fff5f4', color: '$heart' } },
+    corner: { true: { backgroundColor: '$white' } },
+  },
+});
+
+const Td = styled('td', {
+  padding: '12px 14px',
+  color: '$dark',
+  lineHeight: 1.5,
+  borderBottom: '1px solid #f0f1f3',
+  verticalAlign: 'top',
+  variants: {
+    highlight: { true: { backgroundColor: '#fff9f8' } },
+  },
+});
+
+const RowHeader = styled('th', {
+  padding: '12px 14px',
+  textAlign: 'left',
+  fontWeight: 600,
+  color: '$darkgray',
+  whiteSpace: 'nowrap',
+  borderBottom: '1px solid #f0f1f3',
+  verticalAlign: 'top',
+});
+
+const CardGrid = styled('div', {
+  width: '100%',
+  marginTop: '$md',
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
+  gap: '$md',
+});
+
+const DiffCard = styled('div', {
+  padding: '$md',
+  borderRadius: '$md',
+  border: '1px solid #e8eaec',
+  backgroundColor: '#fafbfc',
+});
+
+const DiffIcon = styled('div', { fontSize: '28px', lineHeight: 1, marginBottom: '$sm' });
+const DiffTitle = styled('h3', { margin: '0 0 6px', fontSize: '$md', fontWeight: 700, color: '$dark' });
+const DiffBody = styled('p', { margin: 0, fontSize: '14px', lineHeight: 1.55, color: '$darkgray' });
+
+const Steps = styled('ol', {
+  width: '100%',
+  maxWidth: '640px',
+  margin: '$md 0 0',
+  padding: '14px 16px 14px 34px',
+  backgroundColor: '#f8f6f4',
+  border: '1px solid #eee',
+  borderRadius: '$md',
+  fontSize: '$base',
+  color: '$dark',
+  lineHeight: 1.6,
+  '& li': { marginBottom: '6px' },
+  '& strong': { color: '$heart' },
+});
+
+const FaqList = styled('div', { width: '100%', maxWidth: '680px', marginTop: '$md' });
+
+const FaqItem = styled('div', {
+  padding: '14px 0',
+  borderBottom: '1px solid #f0f1f3',
+  '&:last-child': { borderBottom: 'none' },
+});
+
+const FaqQ = styled('h3', { margin: '0 0 4px', fontSize: '$md', fontWeight: 700, color: '$dark' });
+const FaqA = styled('p', { margin: 0, fontSize: '$base', lineHeight: 1.6, color: '$darkgray' });
+
+const CtaRow = styled('div', {
+  width: '100%',
+  maxWidth: '640px',
+  marginTop: '$lg',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '$sm',
+});
+
+const SecondaryCTA = styled(Link, {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '100%',
+  padding: '14px 20px',
+  borderRadius: '$md',
+  backgroundColor: '$white',
+  color: '$heart',
+  border: '1px solid $heart',
+  fontSize: '$md',
+  fontWeight: 600,
+  textDecoration: 'none',
+  transition: 'background-color 0.15s ease',
+  '&:hover': { backgroundColor: '#fff5f4' },
+});
+
+/* ---------------------------------------------------------------------- page */
+
+export default function VsPage() {
+  return (
+    <PageWrapper>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <Container>
+        <PageHeading>Donation-based outreach vs. cold email vs. paid gifting</PageHeading>
+        <PageSubheading>What if every sales call also helped a non-profit?</PageSubheading>
+
+        <Lede>
+          Cold outreach interrupts a stranger. A gift buys their attention.{' '}
+          <strong>Donation-based outreach</strong> earns a warm meeting by funding a cause the
+          recipient chooses — so the conversation starts on goodwill, and you only pay when they
+          say yes.
+        </Lede>
+
+        <SectionHeading>How the three approaches compare</SectionHeading>
+        <TableScroll>
+          <Table>
+            <thead>
+              <tr>
+                <Th corner scope="col">
+                  &nbsp;
+                </Th>
+                {COLUMNS.map((c) => (
+                  <Th key={c.key} highlight={c.highlight} scope="col">
+                    {c.label}
+                  </Th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {ROWS.map((row) => (
+                <tr key={row.dimension}>
+                  <RowHeader scope="row">{row.dimension}</RowHeader>
+                  {COLUMNS.map((c) => (
+                    <Td key={c.key} highlight={c.highlight}>
+                      {row.cells[c.key]}
+                    </Td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        </TableScroll>
+
+        <SectionHeading>Why donation-based outreach is different</SectionHeading>
+        <CardGrid>
+          {DIFFERENTIATORS.map((d) => (
+            <DiffCard key={d.title}>
+              <DiffIcon aria-hidden>{d.icon}</DiffIcon>
+              <DiffTitle>{d.title}</DiffTitle>
+              <DiffBody>{d.body}</DiffBody>
+            </DiffCard>
+          ))}
+        </CardGrid>
+
+        <SectionHeading>How it works on DonaTalk</SectionHeading>
+        <Steps>
+          {STEPS.map((s, i) => (
+            <li key={i}>{s}</li>
+          ))}
+        </Steps>
+
+        <SectionHeading>Frequently asked</SectionHeading>
+        <FaqList>
+          {FAQ.map((f) => (
+            <FaqItem key={f.q}>
+              <FaqQ>{f.q}</FaqQ>
+              <FaqA>{f.a}</FaqA>
+            </FaqItem>
+          ))}
+        </FaqList>
+
+        <CtaRow>
+          <SecondaryHint>Ready to try warm, charitable outreach?</SecondaryHint>
+          <PrimaryCTA href="/listeners">Browse people to pitch →</PrimaryCTA>
+          <SecondaryCTA href="/pitcher/signup">Start pitching — join as a pitcher</SecondaryCTA>
+        </CtaRow>
+      </Container>
+    </PageWrapper>
+  );
+}

--- a/docs/company/BACKLOG.md
+++ b/docs/company/BACKLOG.md
@@ -2,7 +2,7 @@
 
 > Ordered work queue. Each scheduled run advances the top **unblocked** item.
 > Status: ⬜ todo · 🟡 in progress · ✅ done · 🔴 BLOCKED
-> Last updated: 2026-07-09 (run 6)
+> Last updated: 2026-07-09 (run 7)
 
 ## Now (Obj 1 — the machine)
 | # | Item | KR | Status |
@@ -36,7 +36,7 @@
 |---|------|----|--------|
 | 16 | Cluster A listicle — "cold email alternatives" (`donatalk.com/blog/`) | 2-1→2-3 | 🟡 drafted `docs/company/content/cold-email-alternatives.md` (publish-ready, brand-voice, Sec 6-truthful). **Publish blocked:** WP App Password pending rotation + publish pipeline (item 14) unbuilt |
 | 17 | Cluster B pillar + template — "how to get warm introductions" | 2-1→2-3 | ⬜ todo (next content piece) |
-| 18 | Cluster C explainer + app `/vs` page — "donation-based outreach" | 2-1→2-3 | ⬜ todo (app surface = fully autonomous/deployable) |
+| 18 | Cluster C explainer + app `/vs` page — "donation-based outreach" | 2-1→2-3 | 🟡 **app `/vs` page built + shipping (run 7, v0.13.0, PR pending):** static category-defining comparison (cold email vs paid gifting vs donation-based), comparison table + differentiators + how-it-works + FAQ, WebPage/Breadcrumb/**FAQPage** JSON-LD, full metadata, added to sitemap. Deploy gates green (tsc clean, 598 tests pass, no §3b surface). Remaining: thin WP `what-is-donation-based-outreach` explainer (WP-publish-blocked, item 14b) + impact calculator (fast-follow) |
 | 14b | WordPress publish pipeline: markdown draft → WP REST draft post (reads creds from env) | 2-2 | ⬜ todo — **gate on WP App Password rotation first** |
 
 ## Follow-ups (unblocked, this cycle)
@@ -47,6 +47,8 @@
   scheduler invoke the probe + metrics collectors directly (outside `claude -p`) so they run with
   full host PowerShell. Worked around this run via a node helper. *(Writing `.claude/settings.local.json`
   is itself permission-gated for the agent — so this needs the board/host to apply, or the runner to own it.)*
+
+- **Orphaned worktree pollutes `npm run test`.** `.claude/worktrees/company-os-scaffold/` (the dead OneDrive-migration copy, flagged safe-to-delete run 4) ships Playwright `e2e/*.spec.ts` that vitest picks up → **7 "failed" test *files*** every run (`test.beforeAll() not expected` — Playwright specs loaded under vitest), while all **598 real unit tests pass**. It's untracked (`??`), so it isn't in any PR and can't be removed via a normal commit; the runner's `main` reset doesn't clean untracked dirs. Fix: host/board deletes the stray dir (or add `.claude/worktrees/` to vitest's exclude). Degrades the KR1 test-gate signal until removed.
 
 ## Still blocked on board
 - Always-on scheduler host (item 6).

--- a/docs/company/metrics/awareness-log.csv
+++ b/docs/company/metrics/awareness-log.csv
@@ -4,3 +4,4 @@ date_utc,A1,A2,A3,A4,A5,A6,A7,note
 2026-07-09,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger
 2026-07-09,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger
 2026-07-09,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger
+2026-07-09,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger

--- a/docs/company/metrics/funnel-log.csv
+++ b/docs/company/metrics/funnel-log.csv
@@ -4,3 +4,4 @@ date_utc,F1,F2,F3,F4,R1,note
 2026-07-09,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account
 2026-07-09,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account
 2026-07-09,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account
+2026-07-09,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account

--- a/docs/company/metrics/ops-health-log.csv
+++ b/docs/company/metrics/ops-health-log.csv
@@ -7,3 +7,4 @@ ts_utc,run_type,H1,H2,H3,H4,note
 20260709T162041Z,probe,success,none,pass,not-run,critical-path probe
 20260709T192040Z,probe,success,none,pass,not-run,critical-path probe
 20260709T192239Z,probe,success,none,pass,not-run,critical-path probe
+20260709T222040Z,probe,success,none,pass,not-run,critical-path probe

--- a/docs/company/reports/2026-07-09-daily.md
+++ b/docs/company/reports/2026-07-09-daily.md
@@ -169,3 +169,77 @@ fully-autonomous/deployable content next.
 - Ops-script allowlist for headless agent runs — still board/host-side.
 
 **Alerts:** none this run.
+
+---
+
+## Run 7 — 20260709T2220Z (daily-ops, every-3h)
+
+**Headline:** Shipped the first fully-autonomous Obj-2 content surface — a live app
+`/vs` page that names + defends the "donation-based outreach" category (Cluster C),
+the one content piece in the strategy that doesn't need the blocked WordPress
+credential. v0.13.0.
+
+**Health snapshot**
+- Synthetic probe: **green** — newest artifact `site-check-20260709T222040Z.json`,
+  `allOk:true`, `/`, `/listeners`, `/login` all 200.
+- Metrics coverage (KR1-2, runner-collected this run): ops-health
+  `20260709T222040Z,probe,success,none,pass` appended; awareness `A1-A6 n/a`
+  (GSC/GA4 creds pending) / `A7=0` (empty ledger); funnel `F1-F4/R1 n/a`
+  (Firebase Admin pending). No fabricated numbers.
+
+**What advanced (Obj 2 — KR2-1 → 2-3)**
+- **Backlog #18 → 🟡 built + shipping:** new `app/vs/page.tsx` (`/vs`) — a static,
+  category-defining comparison page: *"Donation-based outreach vs. cold email vs.
+  paid gifting."* Comparison table (what you send / who benefits / reply dynamic /
+  cost / brand effect), 3 differentiators, how-it-works steps, and a 4-item FAQ.
+  Ships **WebPage + BreadcrumbList + FAQPage JSON-LD** and full metadata
+  (title/description/canonical/OG/Twitter). Registered in `app/sitemap.ts`
+  (priority 0.7). Anchored to "What if every sales call also helped a non-profit?".
+- **Content Rules (§6) honored:** compares three *approaches* at the category
+  level — **no named competitor products, non-defamatory**. First-party claims
+  (donation-to-book, listener picks the cause, 4.9% fee, decline = no charge)
+  mirror the live product. The ~1% cold-email figure is framed as a *widely-reported
+  industry* number, not a DonaTalk metric.
+- **Versioning:** 0.12.0 → **0.13.0** (MINOR, new feature); `package.json`,
+  `CHANGELOG.md`, `docs/product-reference.md`, `docs/developer-reference.md`
+  (route table: added `/vs`, `/listeners`; corrected `/` redirect target) updated.
+
+**Why item 18, not 16/17:** #16 (Cluster A listicle, drafted) and #17 (Cluster B
+pillar) both target **WordPress**, whose publish path is blocked on the pending WP
+App Password rotation + unbuilt pipeline (#14b) — drafting more of them just piles
+up unpublishable assets. #18's app surface is **fully autonomous + deployable**
+(the run-6 brief already flagged it as the next autonomous step), so it's the item
+that produces *live, indexable* value this run and directly attacks the Obj-2 gap
+(zero non-branded discovery).
+
+**Deploy gates (Charter §4)**
+- `npx tsc --noEmit` — **clean**.
+- `npm run test` — **598 unit tests pass, 0 test failures**. (7 "failed" test
+  *files* are pre-existing environmental noise: Playwright `e2e/*.spec.ts` from the
+  orphaned, untracked `.claude/worktrees/company-os-scaffold/` copy that vitest
+  wrongly loads — not my change, logged as a Backlog follow-up.)
+- No **§3b-gated** surface touched (marketing page + sitemap line + docs only).
+- Version bump + CHANGELOG + reference docs — **done**.
+- `npm run build`: `/vs` **compiled successfully**; the build's only stop is at
+  `/listeners`' page-data collection hitting `auth/invalid-api-key` — a **local-env
+  limitation** (no Firebase creds in this headless run, correct per §4/no-secrets),
+  not a regression. That route has built fine on Vercel since v0.12.0, where real
+  env exists. `/vs` is a static route with **zero Firebase dependency**.
+
+**Shipping** — non-gated app change with all deploy gates met → **branch
+`content/vs-donation-based-outreach` → PR → merge** (§3a authorizes merging
+non-gated PRs; matches the #21 app-deploy cadence; merge triggers Vercel prod
+deploy of v0.13.0). Post-deploy critical-path probe verification lands on the next
+probe cycle (ps1 execution is agent-gated in this headless session — known KR1-1
+gap); **`/vs` is an isolated additive route and cannot affect the probe's critical
+paths** (`/`, `/listeners`, `/login`), so prod safety is unaffected regardless.
+
+**What's blocked**
+- Scheduler host (item 6), approved posting accounts (item 15), **WP App Password
+  rotation** — unchanged, board-side.
+- True live-fire rollback test — deferred by design.
+- Ops-script allowlist for headless agent runs — still board/host-side.
+- **New:** orphaned `.claude/worktrees/` dir degrades the test-gate signal (7 phantom
+  file failures) — needs host/board deletion or a vitest exclude (Backlog follow-up).
+
+**Alerts:** none this run.

--- a/docs/developer-reference.md
+++ b/docs/developer-reference.md
@@ -1,6 +1,6 @@
 # DonaTalk - Developer Reference
 
-> Last updated: 2026-07-09 | Version: 0.12.0
+> Last updated: 2026-07-09 | Version: 0.13.0
 
 ## Project Overview
 
@@ -104,7 +104,9 @@ donatalk/
 
 | Route | File | Purpose |
 |-------|------|---------|
-| `/` | `app/page.tsx` | Redirects to `/login` |
+| `/` | `app/page.tsx` | Redirects to `/listeners` (browse-before-signup acquisition surface) |
+| `/listeners` | `app/listeners/page.tsx` | Public browse of live listeners + their causes (SSR, SEO) |
+| `/vs` | `app/vs/page.tsx` | SEO comparison page: donation-based outreach vs. cold email vs. paid gifting (static, FAQ JSON-LD) |
 | `/admin` | `app/admin/page.tsx` | Admin dashboard (email whitelist protected) |
 | `/login` | `app/login/page.tsx` | Email/password + Google login |
 | `/choose-a-profile` | `app/choose-a-profile/page.tsx` | Switch between Pitcher/Listener roles |

--- a/docs/product-reference.md
+++ b/docs/product-reference.md
@@ -1,6 +1,6 @@
 # DonaTalk - Product Reference
 
-> Last updated: 2026-07-09 | Version: 0.12.0
+> Last updated: 2026-07-09 | Version: 0.13.0
 
 ## Product Vision
 

--- a/ops/logs/site-check-20260709T222040Z.json
+++ b/ops/logs/site-check-20260709T222040Z.json
@@ -1,0 +1,22 @@
+﻿{
+    "ts":  "20260709T222040Z",
+    "base":  "https://app.donatalk.com",
+    "allOk":  true,
+    "checks":  [
+                   {
+                       "path":  "/",
+                       "status":  200,
+                       "ok":  true
+                   },
+                   {
+                       "path":  "/listeners",
+                       "status":  200,
+                       "ok":  true
+                   },
+                   {
+                       "path":  "/login",
+                       "status":  200,
+                       "ok":  true
+                   }
+               ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pitcher-platform",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## What
New static SEO page **`/vs`** (`app/vs/page.tsx`) — the Cluster C, category-defining comparison page from the keyword strategy (BACKLOG #18): **"Donation-based outreach vs. cold email vs. paid gifting."**

- Comparison table (what you send / who benefits / reply dynamic / cost / brand effect)
- 3 differentiators + how-it-works steps + 4-item FAQ
- **WebPage + BreadcrumbList + FAQPage JSON-LD** + full metadata (title/description/canonical/OG/Twitter)
- Registered in `app/sitemap.ts`
- Anchored to *"What if every sales call also helped a non-profit?"*

## Why
Obj-2's gap is **zero non-branded discovery**. This is the one strategy content piece that ships **without** the blocked WordPress credential — an app surface DonaTalk fully controls and can index now. It names + defends the ownable category.

## Content rules (Charter §6)
Compares three *approaches* at the category level — **no named competitors, non-defamatory**. First-party claims (donation-to-book, listener picks the cause, 4.9% fee, decline = no charge) mirror the live product. The ~1% cold-email figure is framed as a widely-reported industry number, not a DonaTalk metric.

## Deploy gates (Charter §4)
- ✅ `npx tsc --noEmit` clean
- ✅ `npm run test` — **598 unit tests pass, 0 test failures** (7 "failed" *files* are pre-existing env noise: Playwright specs from the orphaned untracked `.claude/worktrees/` copy that vitest loads — not this change)
- ✅ No §3b-gated surface (marketing page + sitemap + docs only)
- ✅ v0.12.0 → **0.13.0** + CHANGELOG + reference docs
- ✅ `next build`: `/vs` compiled successfully; build's only stop is `/listeners` needing Firebase env locally (env-only, unchanged since v0.12.0). `/vs` has zero Firebase dependency.

`/vs` is an **isolated additive route** — it cannot affect the critical probe paths (`/`, `/listeners`, `/login`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)