### PR TITLE
feat(seo): /calculator outreach cost & charitable-impact page (v0.14.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to DonaTalk are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [SemVer](https://semver.org/).
 
+## [0.14.0] - 2026-07-10
+
+### Added (SEO content — Cluster C)
+- `app/calculator/page.tsx` + `app/calculator/OutreachCalculator.tsx` — outreach cost & charitable-impact calculator (`/calculator`). Server component renders SEO metadata + JSON-LD (WebApplication + BreadcrumbList + FAQPage); the interactive math is a client child. Given the visitor's target meetings, donation amount, and an (editable, ~1% default) cold-outreach reply rate, it shows monthly donation impact, DonaTalk's 4.9% fee cost, all-in cost per booked meeting, and the cold-message volume they'd send instead. All outputs are arithmetic on visitor inputs — no invented metrics (Charter Sec 6); first-party facts ($10 minimum, 4.9% fee, decline = no charge) mirror the live product.
+- `/calculator` added to `app/sitemap.ts` static routes (priority 0.7, monthly).
+
 ## [0.13.0] - 2026-07-09
 
 ### Added (SEO content — Cluster C)

--- a/app/calculator/OutreachCalculator.tsx
+++ b/app/calculator/OutreachCalculator.tsx
@@ -1,0 +1,250 @@
+// app/calculator/OutreachCalculator.tsx
+//
+// Client-side "cost of outreach + charitable impact" calculator for the
+// Cluster C content surface. All outputs are arithmetic on the visitor's own
+// inputs — no invented DonaTalk metrics (Charter Sec 6). First-party facts are
+// truthful and mirror the live product: donations start at $10, DonaTalk takes
+// a 4.9% fee on committed donations, and a declined meeting is never charged.
+// The cold-outreach reply rate is an *industry estimate the visitor controls*
+// (default ~1%, widely reported), used only to contrast volume — never claimed
+// as a DonaTalk result.
+
+'use client';
+
+import { useState } from 'react';
+import { styled } from '@/styles/stitches.config';
+
+const FEE_RATE = 0.049; // 4.9% fee on committed donations (live product fact)
+const MIN_DONATION = 10; // DonaTalk donations start at $10 (live product fact)
+
+function clampNumber(value: number, min: number, max: number): number {
+  if (Number.isNaN(value)) return min;
+  return Math.min(max, Math.max(min, value));
+}
+
+function money(n: number): string {
+  return n.toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: n < 100 ? 2 : 0,
+  });
+}
+
+/* --------------------------------------------------------------------- styles */
+
+const Panel = styled('div', {
+  width: '100%',
+  maxWidth: '680px',
+  marginTop: '$md',
+  padding: '$md',
+  borderRadius: '$md',
+  border: '1px solid #e8eaec',
+  backgroundColor: '#fafbfc',
+});
+
+const Field = styled('div', {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '4px',
+  padding: '10px 0',
+  borderBottom: '1px solid #f0f1f3',
+  '&:last-child': { borderBottom: 'none' },
+});
+
+const FieldLabel = styled('label', {
+  fontSize: '14px',
+  fontWeight: 600,
+  color: '$dark',
+});
+
+const FieldHint = styled('span', {
+  fontSize: '12px',
+  color: '$darkgray',
+  fontWeight: 400,
+});
+
+const InputRow = styled('div', {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '$sm',
+});
+
+const Prefix = styled('span', {
+  fontSize: '$md',
+  fontWeight: 600,
+  color: '$darkgray',
+});
+
+const NumberInput = styled('input', {
+  flex: 1,
+  width: '100%',
+  padding: '10px 12px',
+  fontSize: '$md',
+  fontFamily: 'inherit',
+  color: '$dark',
+  border: '1px solid #dfe3e6',
+  borderRadius: '$sm',
+  backgroundColor: '$white',
+  '&:focus': { outline: 'none', borderColor: '$heart' },
+});
+
+const ResultsGrid = styled('div', {
+  width: '100%',
+  maxWidth: '680px',
+  marginTop: '$md',
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+  gap: '$md',
+});
+
+const ResultCard = styled('div', {
+  padding: '$md',
+  borderRadius: '$md',
+  border: '1px solid #e8eaec',
+  backgroundColor: '$white',
+  variants: {
+    highlight: {
+      true: { borderColor: '$heart', backgroundColor: '#fff9f8' },
+    },
+  },
+});
+
+const ResultIcon = styled('div', { fontSize: '24px', lineHeight: 1, marginBottom: '6px' });
+const ResultValue = styled('div', {
+  fontSize: '$xl',
+  fontWeight: 700,
+  color: '$dark',
+  lineHeight: 1.1,
+  variants: { heart: { true: { color: '$heart' } } },
+});
+const ResultLabel = styled('div', { margin: '6px 0 0', fontSize: '13px', color: '$darkgray', lineHeight: 1.5 });
+
+const Footnote = styled('p', {
+  width: '100%',
+  maxWidth: '680px',
+  margin: '$md 0 0',
+  fontSize: '12px',
+  color: '$darkgray',
+  lineHeight: 1.5,
+  textAlign: 'center',
+});
+
+/* ----------------------------------------------------------------------- calc */
+
+export default function OutreachCalculator() {
+  const [meetings, setMeetings] = useState(10);
+  const [donation, setDonation] = useState(25);
+  const [replyRate, setReplyRate] = useState(1);
+
+  const m = clampNumber(meetings, 1, 1000);
+  const d = clampNumber(donation, MIN_DONATION, 10000);
+  const r = clampNumber(replyRate, 0.1, 100);
+
+  const impact = m * d; // donated to causes if every meeting is accepted
+  const fee = impact * FEE_RATE; // what DonaTalk charges you
+  const costPerMeeting = d * (1 + FEE_RATE);
+  const coldContacts = Math.round(m / (r / 100)); // strangers to interrupt for m meetings
+
+  return (
+    <>
+      <Panel>
+        <Field>
+          <FieldLabel htmlFor="calc-meetings">
+            Meetings you want to book each month
+          </FieldLabel>
+          <InputRow>
+            <NumberInput
+              id="calc-meetings"
+              type="number"
+              min={1}
+              max={1000}
+              value={meetings}
+              onChange={(e) => setMeetings(e.target.valueAsNumber)}
+            />
+          </InputRow>
+        </Field>
+
+        <Field>
+          <FieldLabel htmlFor="calc-donation">
+            Donation you&rsquo;ll offer per meeting{' '}
+            <FieldHint>(you set it — from ${MIN_DONATION})</FieldHint>
+          </FieldLabel>
+          <InputRow>
+            <Prefix aria-hidden>$</Prefix>
+            <NumberInput
+              id="calc-donation"
+              type="number"
+              min={MIN_DONATION}
+              max={10000}
+              value={donation}
+              onChange={(e) => setDonation(e.target.valueAsNumber)}
+            />
+          </InputRow>
+        </Field>
+
+        <Field>
+          <FieldLabel htmlFor="calc-reply">
+            Cold-outreach reply rate{' '}
+            <FieldHint>(industry estimate ~1% — adjust to yours)</FieldHint>
+          </FieldLabel>
+          <InputRow>
+            <NumberInput
+              id="calc-reply"
+              type="number"
+              min={0.1}
+              max={100}
+              step={0.1}
+              value={replyRate}
+              onChange={(e) => setReplyRate(e.target.valueAsNumber)}
+            />
+            <Prefix aria-hidden>%</Prefix>
+          </InputRow>
+        </Field>
+      </Panel>
+
+      <ResultsGrid role="status" aria-live="polite">
+        <ResultCard highlight>
+          <ResultIcon aria-hidden>💝</ResultIcon>
+          <ResultValue heart>{money(impact)}</ResultValue>
+          <ResultLabel>
+            donated to causes each month, if every meeting is accepted
+          </ResultLabel>
+        </ResultCard>
+
+        <ResultCard>
+          <ResultIcon aria-hidden>💸</ResultIcon>
+          <ResultValue>{money(fee)}</ResultValue>
+          <ResultLabel>
+            your cost — DonaTalk&rsquo;s 4.9% fee on committed donations. Declined
+            meetings cost you nothing.
+          </ResultLabel>
+        </ResultCard>
+
+        <ResultCard>
+          <ResultIcon aria-hidden>🎟️</ResultIcon>
+          <ResultValue>{money(costPerMeeting)}</ResultValue>
+          <ResultLabel>
+            all-in per booked meeting ({money(d)} donation + fee) — and it funds a
+            cause, not a gift card
+          </ResultLabel>
+        </ResultCard>
+
+        <ResultCard>
+          <ResultIcon aria-hidden>📨</ResultIcon>
+          <ResultValue>{coldContacts.toLocaleString('en-US')}</ResultValue>
+          <ResultLabel>
+            cold messages you&rsquo;d send instead at {r}% reply — strangers
+            interrupted, no cause helped
+          </ResultLabel>
+        </ResultCard>
+      </ResultsGrid>
+
+      <Footnote>
+        Figures are estimates from your own inputs, not guaranteed results. The
+        cold-message count assumes every reply became a meeting — optimistic for
+        cold outreach, so the real gap is usually wider. DonaTalk&rsquo;s $10
+        minimum and 4.9% fee are live product facts.
+      </Footnote>
+    </>
+  );
+}

--- a/app/calculator/page.tsx
+++ b/app/calculator/page.tsx
@@ -1,0 +1,212 @@
+// app/calculator/page.tsx
+//
+// Cluster C ("donation-based outreach") conversion asset: an outreach cost +
+// charitable-impact calculator. Server component so metadata and JSON-LD are
+// server-rendered for SEO; the interactive math lives in the client child
+// <OutreachCalculator/>. No data reads — safe to prerender. Category-level
+// framing only (no named competitors) per Charter Sec 6; first-party claims
+// ($10 minimum, 4.9% fee, decline = no charge) mirror the live product.
+
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import { styled } from '@/styles/stitches.config';
+import PageWrapper from '@/components/layout/PageWrapper';
+import { PageHeading, PageSubheading, PrimaryCTA, SecondaryHint } from '@/components/ui/profileCards';
+import OutreachCalculator from './OutreachCalculator';
+
+const BASE = process.env.NEXT_PUBLIC_BASE_URL ?? 'https://app.donatalk.com';
+
+const META_DESCRIPTION =
+  'Free calculator: see what booking meetings with donation-based outreach costs you (a 4.9% fee, nothing when declined), how much it donates to causes, and how many cold messages you would send instead.';
+
+export const metadata: Metadata = {
+  title: 'Cold Outreach Cost & Charitable Impact Calculator',
+  description: META_DESCRIPTION,
+  keywords: [
+    'cold outreach cost calculator',
+    'cost of cold email',
+    'donation-based outreach',
+    'cost per meeting booked',
+    'warm introduction cost',
+    'charitable sales outreach',
+  ],
+  alternates: { canonical: '/calculator' },
+  openGraph: {
+    type: 'website',
+    url: `${BASE}/calculator`,
+    title: 'Cold Outreach Cost & Charitable Impact Calculator',
+    description: META_DESCRIPTION,
+    images: [{ url: '/logo%20horizontal%20with%20text.png', alt: 'DonaTalk' }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Cold Outreach Cost & Charitable Impact Calculator',
+    description: META_DESCRIPTION,
+    images: ['/logo%20horizontal%20with%20text.png'],
+  },
+  robots: { index: true, follow: true },
+};
+
+/* ------------------------------------------------------------------- content */
+
+const FAQ: { q: string; a: string }[] = [
+  {
+    q: 'What does donation-based outreach cost?',
+    a: 'You set the donation you offer per meeting (from $10). DonaTalk charges a 4.9% fee on donations that are committed when a meeting is accepted. If the recipient declines, nothing is charged — so your spend follows real conversations, not sent volume.',
+  },
+  {
+    q: 'How is the cost per meeting calculated?',
+    a: 'Cost per booked meeting is your chosen donation plus the 4.9% fee on it. For a $25 donation that is $26.23 all-in — and the $25 funds a non-profit the recipient chose, rather than a gift card or swag.',
+  },
+  {
+    q: 'Where does the cold-outreach comparison come from?',
+    a: 'The cold-message count is arithmetic on the reply rate you enter (defaulting to the widely reported ~1%). It assumes every reply turned into a meeting, which is optimistic for cold outreach — so the real volume gap is usually larger, not smaller. It is an estimate from your inputs, not a guaranteed result.',
+  },
+  {
+    q: 'Is the donation tax-deductible?',
+    a: 'DonaTalk directs donations to the non-profit a recipient chooses. Whether a given donation is tax-deductible for you depends on the organization and your own tax situation — check with the non-profit and a tax professional. DonaTalk does not provide tax advice.',
+  },
+];
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'WebApplication',
+      '@id': `${BASE}/calculator#app`,
+      name: 'DonaTalk Outreach Cost & Impact Calculator',
+      url: `${BASE}/calculator`,
+      applicationCategory: 'BusinessApplication',
+      operatingSystem: 'Web',
+      description: META_DESCRIPTION,
+      offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+      isPartOf: { '@id': `${BASE}/#website` },
+    },
+    {
+      '@type': 'BreadcrumbList',
+      '@id': `${BASE}/calculator#breadcrumb`,
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'DonaTalk', item: BASE },
+        { '@type': 'ListItem', position: 2, name: 'Outreach cost & impact calculator', item: `${BASE}/calculator` },
+      ],
+    },
+    {
+      '@type': 'FAQPage',
+      '@id': `${BASE}/calculator#faq`,
+      mainEntity: FAQ.map((f) => ({
+        '@type': 'Question',
+        name: f.q,
+        acceptedAnswer: { '@type': 'Answer', text: f.a },
+      })),
+    },
+  ],
+};
+
+/* -------------------------------------------------------------------- styles */
+
+const Container = styled('div', {
+  width: '100%',
+  maxWidth: '760px',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  padding: '0 $md',
+});
+
+const Lede = styled('p', {
+  width: '100%',
+  maxWidth: '640px',
+  margin: '$sm 0 0',
+  fontSize: '$md',
+  lineHeight: 1.6,
+  color: '$dark',
+  textAlign: 'center',
+  '& strong': { color: '$heart' },
+});
+
+const SectionHeading = styled('h2', {
+  width: '100%',
+  maxWidth: '640px',
+  margin: '$lg 0 $sm',
+  fontSize: '$xl',
+  fontWeight: 700,
+  color: '$dark',
+  textAlign: 'center',
+});
+
+const FaqList = styled('div', { width: '100%', maxWidth: '680px', marginTop: '$sm' });
+const FaqItem = styled('div', {
+  padding: '14px 0',
+  borderBottom: '1px solid #f0f1f3',
+  '&:last-child': { borderBottom: 'none' },
+});
+const FaqQ = styled('h3', { margin: '0 0 4px', fontSize: '$md', fontWeight: 700, color: '$dark' });
+const FaqA = styled('p', { margin: 0, fontSize: '$base', lineHeight: 1.6, color: '$darkgray' });
+
+const CtaRow = styled('div', {
+  width: '100%',
+  maxWidth: '640px',
+  marginTop: '$lg',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '$sm',
+});
+
+const SecondaryCTA = styled(Link, {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '100%',
+  padding: '14px 20px',
+  borderRadius: '$md',
+  backgroundColor: '$white',
+  color: '$heart',
+  border: '1px solid $heart',
+  fontSize: '$md',
+  fontWeight: 600,
+  textDecoration: 'none',
+  transition: 'background-color 0.15s ease',
+  '&:hover': { backgroundColor: '#fff5f4' },
+});
+
+/* ---------------------------------------------------------------------- page */
+
+export default function CalculatorPage() {
+  return (
+    <PageWrapper>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <Container>
+        <PageHeading>What does your outreach really cost — and who does it help?</PageHeading>
+        <PageSubheading>What if every sales call also helped a non-profit?</PageSubheading>
+
+        <Lede>
+          Cold outreach spends your time and budget interrupting strangers.{' '}
+          <strong>Donation-based outreach</strong> turns the same goal into a warm
+          meeting and a gift to a cause the recipient chose. Set your numbers and
+          see the difference.
+        </Lede>
+
+        <OutreachCalculator />
+
+        <SectionHeading>Frequently asked</SectionHeading>
+        <FaqList>
+          {FAQ.map((f) => (
+            <FaqItem key={f.q}>
+              <FaqQ>{f.q}</FaqQ>
+              <FaqA>{f.a}</FaqA>
+            </FaqItem>
+          ))}
+        </FaqList>
+
+        <CtaRow>
+          <SecondaryHint>Ready to turn outreach into impact?</SecondaryHint>
+          <PrimaryCTA href="/listeners">Browse people to pitch →</PrimaryCTA>
+          <SecondaryCTA href="/vs">See how donation-based outreach compares →</SecondaryCTA>
+        </CtaRow>
+      </Container>
+    </PageWrapper>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -34,6 +34,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${BASE}/`, lastModified: now, changeFrequency: 'daily', priority: 1 },
     { url: `${BASE}/listeners`, lastModified: now, changeFrequency: 'daily', priority: 0.9 },
     { url: `${BASE}/vs`, lastModified: now, changeFrequency: 'monthly', priority: 0.7 },
+    { url: `${BASE}/calculator`, lastModified: now, changeFrequency: 'monthly', priority: 0.7 },
     { url: `${BASE}/pitcher/signup`, lastModified: now, changeFrequency: 'monthly', priority: 0.6 },
     { url: `${BASE}/listener/signup`, lastModified: now, changeFrequency: 'monthly', priority: 0.6 },
     { url: `${BASE}/login`, lastModified: now, changeFrequency: 'monthly', priority: 0.3 },

--- a/docs/company/BACKLOG.md
+++ b/docs/company/BACKLOG.md
@@ -2,7 +2,7 @@
 
 > Ordered work queue. Each scheduled run advances the top **unblocked** item.
 > Status: ⬜ todo · 🟡 in progress · ✅ done · 🔴 BLOCKED
-> Last updated: 2026-07-10 (run 8)
+> Last updated: 2026-07-10 (run 9)
 
 ## Now (Obj 1 — the machine)
 | # | Item | KR | Status |
@@ -36,7 +36,7 @@
 |---|------|----|--------|
 | 16 | Cluster A listicle — "cold email alternatives" (`donatalk.com/blog/`) | 2-1→2-3 | 🟡 drafted `docs/company/content/cold-email-alternatives.md` (publish-ready, brand-voice, Sec 6-truthful). **Publish blocked:** WP App Password pending rotation + publish pipeline (item 14) unbuilt |
 | 17 | Cluster B pillar + template — "how to get warm introductions" | 2-1→2-3 | 🟡 drafted `docs/company/content/how-to-get-warm-introductions.md` (run 8): definitional pillar + how-to (double opt-in ask) + 2 original copy-paste templates (ask-connector + forwardable blurb) + exec sub-cluster + FAQ; bridges to Cluster C via donation-based outreach for the "no mutual connection" case. Brand-voice, Sec-6 truthful (warm-vs-cold stated qualitatively, ~1% flagged to confirm). **Publish blocked:** WP App Password rotation + pipeline (items 14/14b) |
-| 18 | Cluster C explainer + app `/vs` page — "donation-based outreach" | 2-1→2-3 | 🟡 **app `/vs` page shipped + merged (v0.13.0, PR #29, run 7):** static category-defining comparison (cold email vs paid gifting vs donation-based), comparison table + differentiators + how-it-works + FAQ, WebPage/Breadcrumb/**FAQPage** JSON-LD, full metadata, in sitemap. Live (`app/vs/page.tsx` on `main`). Remaining: thin WP `what-is-donation-based-outreach` explainer (WP-publish-blocked, item 14b) + impact calculator (fast-follow) |
+| 18 | Cluster C explainer + app `/vs` page — "donation-based outreach" | 2-1→2-3 | 🟡 **`/vs` shipped+merged (v0.13.0, PR #29, run 7)** + **impact calculator shipped (v0.14.0, run 9):** `app/calculator/page.tsx` (server: metadata + WebApplication/Breadcrumb/FAQPage JSON-LD) + `OutreachCalculator.tsx` (client: target meetings × donation × editable ~1% reply rate → monthly donation impact, 4.9% fee cost, all-in cost/meeting, cold-message volume). All outputs = arithmetic on visitor input (no invented metrics, Sec 6); in sitemap; cross-links to `/vs` + `/listeners`. tsc clean, 598 unit tests green, non-§3b. Remaining: thin WP `what-is-donation-based-outreach` explainer (WP-publish-blocked, item 14b) |
 | 14b | WordPress publish pipeline: markdown draft → WP REST draft post (reads creds from env) | 2-2 | ⬜ todo — **gate on WP App Password rotation first** |
 
 ## Follow-ups (unblocked, this cycle)
@@ -56,6 +56,6 @@
 - **Rotate** WordPress App Password (transited chat).
 
 ## Later
-- `/vs` competitor/comparison pages; cost-of-cold-outreach calculator.
+- ~~cost-of-cold-outreach calculator~~ ✅ shipped as `/calculator` (v0.14.0, run 9). More `/vs` competitor/comparison pages.
 - Cause-story content series (Listeners' non-profits) for donatalk.com blog.
 - `.env.example`; API rate limiting; cookie consent (from product backlog).

--- a/docs/company/metrics/awareness-log.csv
+++ b/docs/company/metrics/awareness-log.csv
@@ -6,3 +6,4 @@ date_utc,A1,A2,A3,A4,A5,A6,A7,note
 2026-07-09,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger
 2026-07-09,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger
 2026-07-10,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger
+2026-07-10,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger

--- a/docs/company/metrics/funnel-log.csv
+++ b/docs/company/metrics/funnel-log.csv
@@ -6,3 +6,4 @@ date_utc,F1,F2,F3,F4,R1,note
 2026-07-09,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account
 2026-07-09,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account
 2026-07-10,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account
+2026-07-10,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account

--- a/docs/company/metrics/ops-health-log.csv
+++ b/docs/company/metrics/ops-health-log.csv
@@ -10,3 +10,4 @@ ts_utc,run_type,H1,H2,H3,H4,note
 20260709T222040Z,probe,success,none,pass,not-run,critical-path probe
 20260710T012042Z,probe,success,none,pass,not-run,critical-path probe
 20260710T012239Z,probe,success,none,pass,not-run,critical-path probe
+20260710T042040Z,probe,success,none,pass,not-run,critical-path probe

--- a/docs/company/reports/2026-07-10-daily.md
+++ b/docs/company/reports/2026-07-10-daily.md
@@ -69,3 +69,74 @@ batch via the #14b pipeline. Remaining autonomous Obj-2 work: the Cluster C impa
 calculator (fast-follow to the shipped `/vs` page).
 
 **Alerts:** none this run.
+
+---
+
+## Run 9 — 20260710T0420Z (daily-ops, every-3h)
+
+**Headline:** Shipped the **Cluster C impact calculator** (`/calculator`, v0.14.0) —
+the "strong fast-follow" the keyword strategy flagged after `/vs`. An interactive
+outreach cost + charitable-impact tool on the app surface: the last autonomous
+Obj-2 content asset that needs no board credential. tsc clean, 598 unit tests
+green, non-§3b → shipped via PR + merge to `main`.
+
+**Health snapshot**
+- Synthetic probe: **green** — newest artifact `site-check-20260710T042040Z.json`,
+  `allOk:true`, `/`, `/listeners`, `/login` all 200.
+- Metrics coverage (KR1-2, runner-collected this run): ops-health
+  `20260710T042040Z,probe,success,none,pass` appended; awareness `A1-A6 n/a`
+  (GSC/GA4 creds pending) / `A7=0` (empty ledger); funnel `F1-F4/R1 n/a`
+  (Firebase Admin pending). No fabricated numbers.
+
+**What advanced (Obj 2 — KR2-1 → 2-3)**
+- **Backlog #18 → calculator shipped (v0.14.0):**
+  - `app/calculator/page.tsx` — server component; SEO metadata + JSON-LD
+    (WebApplication + BreadcrumbList + FAQPage), intro copy, a 4-item FAQ, and
+    cross-links to `/vs` and `/listeners`.
+  - `app/calculator/OutreachCalculator.tsx` — client component; three inputs
+    (target meetings/month, donation per meeting from $10, and an editable
+    cold-outreach reply rate defaulting to the widely-reported ~1%) drive four
+    live outputs: monthly donation impact, DonaTalk's 4.9% fee cost, all-in cost
+    per booked meeting, and the cold-message volume you'd send instead.
+  - `/calculator` added to `app/sitemap.ts` (priority 0.7, monthly).
+- **Content Rules (§6) honored:** every output is arithmetic on the *visitor's own
+  inputs* — no invented DonaTalk metrics. First-party facts ($10 minimum, 4.9%
+  fee, declined meeting = no charge) mirror the live product. The cold-message
+  count is labeled an estimate and deliberately *optimistic for cold* (assumes
+  every reply became a meeting), so the contrast never overstates DonaTalk. A
+  visible footnote states the figures are projections, not guaranteed results;
+  the tax-deductibility FAQ explicitly declines to give tax advice.
+- **Deploy gates (Charter §4):** `tsc --noEmit` clean; `npm run test` = **598/598
+  unit tests pass** (the 7 phantom test-*file* failures are the known orphaned
+  `.claude/worktrees/` Playwright specs — untracked, pre-existing, not from this
+  change); touches no §3b surface; version bumped 0.13.0 → **0.14.0** + CHANGELOG.
+
+**Why item 18's calculator, not 5/6/16/17:** Obj-1 machine items remain at their
+autonomous ceiling (#5 live-fire deferred-by-design; #6 scheduler host + #15
+posting accounts are board-side). Content items #16 (Cluster A) and #17 (Cluster
+B) are both drafted but **WordPress-publish-blocked** on the pending WP App
+Password rotation + unbuilt pipeline (#14b) — nothing to advance autonomously
+there this run. The calculator is the one remaining Obj-2 asset that lives on the
+**app** surface (no credential needed, deployable under §3a/§4), so it's the top
+truly-unblocked item.
+
+**Shipping** — non-gated app change (new static/client page + sitemap + version +
+CHANGELOG) → **branch `content/outreach-impact-calculator` → PR → merge to
+`main`** (Vercel auto-deploys; matches the #22–#29 cadence). Next run's 6h probe
+validates the live deploy. No §3b gate tripped; no ALERT raised.
+
+**What's blocked** (unchanged, board-side)
+- Scheduler host (#6), approved posting accounts (#15), **WP App Password
+  rotation** (gates content publishing for #16/#17/#14b).
+- True live-fire rollback test — deferred by design.
+- Ops-script allowlist for headless runs; orphaned `.claude/worktrees/` dir still
+  degrades the test-gate signal (7 phantom file failures) — host/board follow-ups.
+
+**Next autonomous Obj-2 work:** with the calculator shipped, the app-surface
+Cluster C assets (`/vs` + `/calculator`) are complete. Remaining Obj-2 content
+(#16 A, #17 B, thin WP C explainer) is all WordPress-blocked → the critical path
+is now the **WP App Password rotation + #14b publish pipeline**. Absent that,
+future runs can iterate app-side SEO (internal linking, more `/vs` comparisons) or
+harden Obj-1 tooling.
+
+**Alerts:** none this run.

--- a/ops/logs/site-check-20260710T012239Z.json
+++ b/ops/logs/site-check-20260710T012239Z.json
@@ -1,0 +1,22 @@
+﻿{
+    "ts":  "20260710T012239Z",
+    "base":  "https://app.donatalk.com",
+    "allOk":  true,
+    "checks":  [
+                   {
+                       "path":  "/",
+                       "status":  200,
+                       "ok":  true
+                   },
+                   {
+                       "path":  "/listeners",
+                       "status":  200,
+                       "ok":  true
+                   },
+                   {
+                       "path":  "/login",
+                       "status":  200,
+                       "ok":  true
+                   }
+               ]
+}

--- a/ops/logs/site-check-20260710T042040Z.json
+++ b/ops/logs/site-check-20260710T042040Z.json
@@ -1,0 +1,22 @@
+﻿{
+    "ts":  "20260710T042040Z",
+    "base":  "https://app.donatalk.com",
+    "allOk":  true,
+    "checks":  [
+                   {
+                       "path":  "/",
+                       "status":  200,
+                       "ok":  true
+                   },
+                   {
+                       "path":  "/listeners",
+                       "status":  200,
+                       "ok":  true
+                   },
+                   {
+                       "path":  "/login",
+                       "status":  200,
+                       "ok":  true
+                   }
+               ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pitcher-platform",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## What

Ships the **Cluster C impact calculator** at `/calculator` (v0.14.0) — the "strong fast-follow" the SEO keyword strategy flagged after the `/vs` page. It's the last autonomous Obj-2 content asset that lives on the app surface (no board credential required).

- `app/calculator/page.tsx` — server component: SEO metadata + JSON-LD (`WebApplication` + `BreadcrumbList` + `FAQPage`), intro copy, 4-item FAQ, cross-links to `/vs` and `/listeners`.
- `app/calculator/OutreachCalculator.tsx` — client component: three inputs (target meetings/month, donation per meeting from $10, editable cold-outreach reply rate defaulting to the widely-reported ~1%) → four live outputs: monthly donation impact, DonaTalk's 4.9% fee cost, all-in cost per booked meeting, and the cold-message volume sent instead.
- `/calculator` added to `app/sitemap.ts` (priority 0.7, monthly).
- Version 0.13.0 → 0.14.0 + CHANGELOG.

## Content rules (Charter §6)

Every output is arithmetic on the visitor's own inputs — **no invented DonaTalk metrics**. First-party facts ($10 minimum, 4.9% fee, declined meeting = no charge) mirror the live product. The cold-message count is labeled an estimate and is deliberately *optimistic for cold outreach* (assumes every reply became a meeting), so the contrast never overstates DonaTalk. A footnote states figures are projections, not guaranteed results; the tax FAQ explicitly declines to give tax advice.

## Deploy gates (Charter §4)

- ✅ `tsc --noEmit` clean
- ✅ `npm run test` — 598/598 unit tests pass (the 7 phantom test-*file* failures are the known orphaned `.claude/worktrees/` Playwright specs — untracked, pre-existing, unrelated to this change)
- ✅ Touches **no §3b surface** (static/client page, sitemap, changelog, version — no money/auth/email/secret)
- ✅ Version bumped + CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)
