### PR TITLE
fix(test): exclude nested .claude worktree from vitest (restore honest 299-test deploy gate)

### DIFF
--- a/docs/company/BACKLOG.md
+++ b/docs/company/BACKLOG.md
@@ -2,7 +2,7 @@
 
 > Ordered work queue. Each scheduled run advances the top **unblocked** item.
 > Status: ⬜ todo · 🟡 in progress · ✅ done · 🔴 BLOCKED
-> Last updated: 2026-07-10 (run 9)
+> Last updated: 2026-07-10 (run 10)
 
 ## Now (Obj 1 — the machine)
 | # | Item | KR | Status |
@@ -48,7 +48,7 @@
   full host PowerShell. Worked around this run via a node helper. *(Writing `.claude/settings.local.json`
   is itself permission-gated for the agent — so this needs the board/host to apply, or the runner to own it.)*
 
-- **Orphaned worktree pollutes `npm run test`.** `.claude/worktrees/company-os-scaffold/` (the dead OneDrive-migration copy, flagged safe-to-delete run 4) ships Playwright `e2e/*.spec.ts` that vitest picks up → **7 "failed" test *files*** every run (`test.beforeAll() not expected` — Playwright specs loaded under vitest), while all **598 real unit tests pass**. It's untracked (`??`), so it isn't in any PR and can't be removed via a normal commit; the runner's `main` reset doesn't clean untracked dirs. Fix: host/board deletes the stray dir (or add `.claude/worktrees/` to vitest's exclude). Degrades the KR1 test-gate signal until removed.
+- ~~**Orphaned worktree pollutes `npm run test`.**~~ ✅ fixed run 10 (`fix/vitest-exclude-worktree`): the anchored `e2e/**`/`node_modules/**` globs only matched at the repo root, so vitest collected the dead `.claude/worktrees/company-os-scaffold/` copy — both its 7 Playwright `e2e/*.spec.ts` (7 "failed" files, `test.beforeAll() not expected`) **and a full duplicate of every unit test** (which is why the count read 598 = 299×2). Broadened exclude to `["**/node_modules/**","**/e2e/**","**/.claude/**"]`. Now the canonical suite runs clean: **24 files / 299 tests pass** (matches Charter §4's "~299"). Deploy test-gate signal restored. The stray untracked dir can still be deleted by host/board for cleanliness, but it no longer pollutes the gate.
 
 ## Still blocked on board
 - Always-on scheduler host (item 6).

--- a/docs/company/DECISIONS.md
+++ b/docs/company/DECISIONS.md
@@ -4,6 +4,9 @@ Important, durable decisions only — the ones that shape how the business runs.
 Operational narrative → `reports/`. Machine logs/alerts → `ops/logs/`.
 Format: `date — decision — one-line rationale`. Newest first.
 
+## 2026-07-10
+- The canonical unit-test count is **299** (24 files), not 598. — vitest's anchored `e2e/**`/`node_modules/**` excludes missed the nested `.claude/worktrees/company-os-scaffold/` copy, so it double-counted every unit test (299×2) and added 7 failing Playwright specs. Exclude broadened to `**/`-prefixed globs incl. `**/.claude/**`; the "598" in earlier run notes was inflated. Charter §4's "~299" is the correct deploy-gate baseline. (Test-tooling fix only — no product code, no version bump, consistent with how ops/infra changes are tracked.)
+
 ## 2026-07-09
 - Validate the deploy auto-rollback via a dry-run self-test (`-SelfTestRollback`), not a real failing prod deploy. — A live rollback test means deliberately breaking production (Charter §2: never leave prod broken); the self-test proves the branch's logic (target/command/re-probe) without an outage. True live-fire is reserved for a controlled, human-in-loop window.
 - Ops scripts are pure-ASCII (no `§`/`—`), not UTF-8-with-typography. — Windows PowerShell 5.1 (the scheduler host shell) reads BOM-less `.ps1` as ANSI and mis-decodes non-ASCII; it had silently broken `deploy-web.ps1` parsing. ASCII is portable across PS 5.1/7 with no BOM dependency.

--- a/docs/company/metrics/awareness-log.csv
+++ b/docs/company/metrics/awareness-log.csv
@@ -7,3 +7,4 @@ date_utc,A1,A2,A3,A4,A5,A6,A7,note
 2026-07-09,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger
 2026-07-10,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger
 2026-07-10,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger
+2026-07-10,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger

--- a/docs/company/metrics/funnel-log.csv
+++ b/docs/company/metrics/funnel-log.csv
@@ -7,3 +7,4 @@ date_utc,F1,F2,F3,F4,R1,note
 2026-07-09,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account
 2026-07-10,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account
 2026-07-10,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account
+2026-07-10,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account

--- a/docs/company/metrics/ops-health-log.csv
+++ b/docs/company/metrics/ops-health-log.csv
@@ -11,3 +11,5 @@ ts_utc,run_type,H1,H2,H3,H4,note
 20260710T012042Z,probe,success,none,pass,not-run,critical-path probe
 20260710T012239Z,probe,success,none,pass,not-run,critical-path probe
 20260710T042040Z,probe,success,none,pass,not-run,critical-path probe
+20260710T072041Z,probe,success,none,pass,not-run,critical-path probe
+20260710T072238Z,probe,success,none,pass,not-run,critical-path probe

--- a/docs/company/reports/2026-07-10-daily.md
+++ b/docs/company/reports/2026-07-10-daily.md
@@ -140,3 +140,65 @@ future runs can iterate app-side SEO (internal linking, more `/vs` comparisons) 
 harden Obj-1 tooling.
 
 **Alerts:** none this run.
+
+---
+
+## Run 10 — 20260710T0720Z (daily-ops, every-3h)
+
+**Headline:** Hardened the deploy test-gate. Fixed the long-standing vitest
+misconfiguration that let the dead `.claude/worktrees/` copy pollute
+`npm run test` — and in doing so uncovered that the "598 tests" figure was
+inflated: the worktree was double-counting every unit test. The canonical suite
+is **24 files / 299 tests** (exactly Charter §4's "~299"), now running clean.
+
+**Health snapshot**
+- Synthetic probe: **green** — newest artifact `site-check-20260710T072041Z.json`,
+  `allOk:true`, `/`, `/listeners`, `/login` all 200.
+- Metrics coverage (KR1-2, runner-collected this run): ops-health
+  `20260710T072041Z,probe,success,none,pass` appended; awareness `A1-A6 n/a`
+  (GSC/GA4 creds pending) / `A7=0` (empty ledger); funnel `F1-F4/R1 n/a`
+  (Firebase Admin pending). No fabricated numbers.
+
+**What advanced (Obj 1 — KR1-1/1-4, the machine)**
+- **Backlog follow-up (worktree pollution) → ✅ fixed** (`fix/vitest-exclude-worktree`):
+  vitest's `exclude` used repo-root-anchored globs (`e2e/**`, `node_modules/**`),
+  which don't match the nested `.claude/worktrees/company-os-scaffold/` copy. So
+  vitest was collecting that dead OneDrive-migration copy — both its 7 Playwright
+  `e2e/*.spec.ts` (the "7 failed files", `test.beforeAll() not expected`) **and a
+  full duplicate of every unit test**, which is why the count read 598 (= 299×2).
+  Broadened exclude to `["**/node_modules/**","**/e2e/**","**/.claude/**"]`.
+- **Result:** `npx tsc --noEmit` clean; `npm run test` now = **24 files / 299
+  tests, 0 failures** — no phantom file failures, no duplicate inflation. This
+  restores an honest green signal for Charter §4 gate 2, which every future
+  auto-deploy depends on. The stray untracked dir can still be deleted for
+  cleanliness, but it no longer corrupts the gate.
+- **Records:** `DECISIONS.md` logs the 598→299 correction so future runs don't
+  read the changed count as tests disappearing; BACKLOG follow-up struck through.
+
+**Why this, not a numbered item:** Every numbered ⬜/🟡 backlog item is at a
+board-side wall this run — #5 live-fire rollback is deferred-by-design; #6
+scheduler host + #15 posting accounts await the Board; #16/#17/#18-WP-explainer
+and #14b are all blocked on the **WP App Password rotation**. The genuinely
+unblocked, in-autonomy work was the test-gate follow-up — and it's not cosmetic:
+a mis-scoped test collector that both hides real failures among phantom ones and
+misreports the pass count directly undermines the KR1-4 deploy gate. Fixing the
+substrate the whole auto-deploy posture rests on is squarely Obj-1 pillar-1 work.
+
+**Shipping** — test-tooling-only change (`vitest.config.mts`) + doc updates. Not
+shippable to production (vitest config isn't in the Next.js build), so no product
+version bump / CHANGELOG entry — consistent with how ops/infra changes are tracked
+(Charter §11: narrative → reports, decision → DECISIONS). Non-§3b →
+**branch `fix/vitest-exclude-worktree` → PR** (keeps main→board-visible; matches
+the #22–#31 cadence).
+
+**What's blocked** (unchanged, board-side)
+- Scheduler host (#6), approved posting accounts (#15), **WP App Password
+  rotation** (gates all remaining content publishing: #16/#17/#14b).
+- True live-fire rollback test — deferred by design.
+- Ops-script allowlist for headless agent runs — host/board-side.
+
+**Next:** the critical path stays the **WP App Password rotation + #14b publish
+pipeline** to unblock the staged Cluster A/B/C content. Absent board action,
+future runs can iterate app-side SEO (internal linking, more `/vs` comparisons).
+
+**Alerts:** none this run.

--- a/ops/logs/site-check-20260710T072041Z.json
+++ b/ops/logs/site-check-20260710T072041Z.json
@@ -1,0 +1,22 @@
+﻿{
+    "ts":  "20260710T072041Z",
+    "base":  "https://app.donatalk.com",
+    "allOk":  true,
+    "checks":  [
+                   {
+                       "path":  "/",
+                       "status":  200,
+                       "ok":  true
+                   },
+                   {
+                       "path":  "/listeners",
+                       "status":  200,
+                       "ok":  true
+                   },
+                   {
+                       "path":  "/login",
+                       "status":  200,
+                       "ok":  true
+                   }
+               ]
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -8,6 +8,11 @@ export default defineConfig({
     },
   },
   test: {
-    exclude: ["node_modules/**", "e2e/**"],
+    // Anchored `e2e/**`/`node_modules/**` only match at the repo root. Broaden to
+    // `**/`-prefixed globs and exclude the whole `.claude/` tree so vitest never
+    // collects Playwright specs from orphaned agent worktrees under
+    // `.claude/worktrees/*/e2e/` (they throw `test.beforeAll() not expected` under
+    // vitest and falsely fail the deploy test-gate).
+    exclude: ["**/node_modules/**", "**/e2e/**", "**/.claude/**"],
   },
 });


### PR DESCRIPTION
## What
vitest's `exclude` used repo-root-anchored globs (`e2e/**`, `node_modules/**`), which don't match the nested dead worktree at `.claude/worktrees/company-os-scaffold/`. So vitest was collecting that OneDrive-migration copy:

- its **7 Playwright `e2e/*.spec.ts`** → `test.beforeAll() not expected` = 7 phantom "failed" test *files* every run, and
- a **full duplicate of every unit test**, inflating the reported count to **598 (= 299×2)**.

Broadened exclude to `["**/node_modules/**", "**/e2e/**", "**/.claude/**"]`.

## Result
- `npx tsc --noEmit` — clean
- `npm run test` — **24 files / 299 tests, 0 failures** (matches Charter §4's "~299")

Restores an honest green signal for the Charter §4 gate-2 deploy check that every future auto-deploy depends on. Previously real failures could hide among the phantom ones and the pass count was doubled.

## Scope / gates
- Test-tooling only (`vitest.config.mts`) — not in the Next.js bundle, so no product version bump / CHANGELOG (consistent with how ops/infra changes are tracked).
- Touches **no §3b surface** (no money/auth/email/secret). Non-gated.
- Also bundles this run's ops evidence (run-10 metric rows + probe artifact) and doc updates (BACKLOG follow-up struck through, DECISIONS logs the 598→299 correction, daily brief run-10 entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)