### PR TITLE
research(seo): growth-research — sourced keyword benchmarks + Cluster C competitor intel + backlink targets

### DIFF
--- a/docs/company/BACKLOG.md
+++ b/docs/company/BACKLOG.md
@@ -2,7 +2,7 @@
 
 > Ordered work queue. Each scheduled run advances the top **unblocked** item.
 > Status: ⬜ todo · 🟡 in progress · ✅ done · 🔴 BLOCKED
-> Last updated: 2026-07-10 (run 10)
+> Last updated: 2026-07-10 (run 11 — growth-research)
 
 ## Now (Obj 1 — the machine)
 | # | Item | KR | Status |
@@ -35,7 +35,7 @@
 | # | Item | KR | Status |
 |---|------|----|--------|
 | 16 | Cluster A listicle — "cold email alternatives" (`donatalk.com/blog/`) | 2-1→2-3 | 🟡 drafted `docs/company/content/cold-email-alternatives.md` (publish-ready, brand-voice, Sec 6-truthful). **Publish blocked:** WP App Password pending rotation + publish pipeline (item 14) unbuilt |
-| 17 | Cluster B pillar + template — "how to get warm introductions" | 2-1→2-3 | 🟡 drafted `docs/company/content/how-to-get-warm-introductions.md` (run 8): definitional pillar + how-to (double opt-in ask) + 2 original copy-paste templates (ask-connector + forwardable blurb) + exec sub-cluster + FAQ; bridges to Cluster C via donation-based outreach for the "no mutual connection" case. Brand-voice, Sec-6 truthful (warm-vs-cold stated qualitatively, ~1% flagged to confirm). **Publish blocked:** WP App Password rotation + pipeline (items 14/14b) |
+| 17 | Cluster B pillar + template — "how to get warm introductions" | 2-1→2-3 | 🟡 drafted `docs/company/content/how-to-get-warm-introductions.md` (run 8): definitional pillar + how-to (double opt-in ask) + 2 original copy-paste templates (ask-connector + forwardable blurb) + exec sub-cluster + FAQ; bridges to Cluster C via donation-based outreach for the "no mutual connection" case. Brand-voice, Sec-6 truthful (warm-vs-cold stated qualitatively, ~1% flagged to confirm). **Publish blocked:** WP App Password rotation + pipeline (items 14/14b). **Pre-publish edit ready (run 11):** swap the qualitative hedge for the now-sourced **warm-intro 20–40% vs cold 1–3%** range (`research/2026-07-10-keywords.md`) — keep as a range, honest. |
 | 18 | Cluster C explainer + app `/vs` page — "donation-based outreach" | 2-1→2-3 | 🟡 **`/vs` shipped+merged (v0.13.0, PR #29, run 7)** + **impact calculator shipped (v0.14.0, run 9):** `app/calculator/page.tsx` (server: metadata + WebApplication/Breadcrumb/FAQPage JSON-LD) + `OutreachCalculator.tsx` (client: target meetings × donation × editable ~1% reply rate → monthly donation impact, 4.9% fee cost, all-in cost/meeting, cold-message volume). All outputs = arithmetic on visitor input (no invented metrics, Sec 6); in sitemap; cross-links to `/vs` + `/listeners`. tsc clean, 598 unit tests green, non-§3b. Remaining: thin WP `what-is-donation-based-outreach` explainer (WP-publish-blocked, item 14b) |
 | 14b | WordPress publish pipeline: markdown draft → WP REST draft post (reads creds from env) | 2-2 | ⬜ todo — **gate on WP App Password rotation first** |
 

--- a/docs/company/OKR.md
+++ b/docs/company/OKR.md
@@ -19,7 +19,7 @@
 | **2-1** | Keyword-strategy doc: **3 validated non-branded clusters** (volume + difficulty), each mapped to a target page. | `plans/seo-keyword-strategy.md` | ✅ done 2026-07-09 (clusters A/B/C; volumes SERP-inferred, confirm w/ tool) |
 | **2-2** | GSC verified on **both** `donatalk.com` and `app.donatalk.com`; sitemaps submitted; baseline captured (indexed pages, impressions, avg position, top-10 queries); metric funnel defined. | `metrics/` + GSC | ✅ GSC+GA4 confirmed, baseline captured, **both sitemaps submitted** (WP + app) 2026-07-09 |
 | **2-2a** | App SEO foundation shipped: `app/robots.ts`, `app/sitemap.ts`, OG/Twitter tags, per-profile metadata, JSON-LD. | app source + deploy | ✅ deployed v0.12.0 (PR #21) 2026-07-09; verified live (robots.txt, sitemap 42 URLs, per-profile OG/JSON-LD); probe green |
-| **2-3** | ≥ **[TBD after baseline]** do-follow backlinks from ≥ **[TBD]** distinct domains, tracked in `backlink-ledger.md`. | `metrics/backlink-ledger.md` | ⬜ not started |
+| **2-3** | ≥ **[TBD after baseline]** do-follow backlinks from ≥ **[TBD]** distinct domains, tracked in `backlink-ledger.md`. | `metrics/backlink-ledger.md` | 🟡 target list built 2026-07-10 (`research/backlink-targets.md` — communities, do-follow guest-post pubs, DR-70+ directories, cause/CSR venues; sourced). Ledger still empty (0) — **execution gated on approved posting accounts (#15)**. Numeric targets still `[TBD]` pending tool baseline. |
 
 ### Open sizing
 Numeric targets on 2-1/2-3 are set **after** the GSC baseline lands — sizing them

--- a/docs/company/metrics/awareness-log.csv
+++ b/docs/company/metrics/awareness-log.csv
@@ -8,3 +8,5 @@ date_utc,A1,A2,A3,A4,A5,A6,A7,note
 2026-07-10,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger
 2026-07-10,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger
 2026-07-10,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger
+2026-07-10,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger
+2026-07-10,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger (growth-research run)

--- a/docs/company/metrics/funnel-log.csv
+++ b/docs/company/metrics/funnel-log.csv
@@ -8,3 +8,5 @@ date_utc,F1,F2,F3,F4,R1,note
 2026-07-10,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account
 2026-07-10,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account
 2026-07-10,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account
+2026-07-10,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account
+2026-07-10,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account (growth-research run)

--- a/docs/company/metrics/ops-health-log.csv
+++ b/docs/company/metrics/ops-health-log.csv
@@ -13,3 +13,4 @@ ts_utc,run_type,H1,H2,H3,H4,note
 20260710T042040Z,probe,success,none,pass,not-run,critical-path probe
 20260710T072041Z,probe,success,none,pass,not-run,critical-path probe
 20260710T072238Z,probe,success,none,pass,not-run,critical-path probe
+20260710T100005Z,probe,success,none,pass,not-run,critical-path probe

--- a/docs/company/plans/seo-keyword-strategy.md
+++ b/docs/company/plans/seo-keyword-strategy.md
@@ -1,6 +1,7 @@
 # DonaTalk — SEO Keyword Strategy
 
-> generated 2026-07-09
+> generated 2026-07-09 · **updated 2026-07-10** (growth-research pass folded in sourced benchmarks +
+> a newly-found Cluster C competitor; see `research/2026-07-10-keywords.md` for the full transcript)
 
 ## 0. Context & method
 
@@ -28,6 +29,7 @@ People who feel the pain DonaTalk solves (1% reply rates) and are shopping for a
 
 ### Cluster B — "Warm introductions / warm outreach" (relationship-selling demand)
 The category buyers move *toward* when they abandon cold outreach. DonaTalk = buy a warm intro by donating to a cause — owning this vocabulary is core.
+- **Sourced demand fact (2026-07-10):** warm-intro reply rates run **20–40% vs cold 1–3%** — an order-of-magnitude lift, cited consistently across independent sources ([askscout.ai](https://askscout.ai/blog/what-is-a-warm-introduction), [launchleads.com](https://www.launchleads.com/lead-generation-strategies/warm-intros-referrals/)). Use this cited *range* in the #17 pillar (replaces the earlier qualitative hedge; keep it a range — the true lift varies by relationship). The gap every source assumes away — *you need a mutual connection* — is exactly what DonaTalk manufactures; that's the bridge into Cluster C.
 - **Head:** warm introduction (sales) / how to get warm intros
 - **Long-tails:** what is a warm introduction · how to ask for a warm intro · warm intro email template · warm intro vs cold outreach · how to get warm introductions B2B · book meetings with hard-to-reach executives · get meetings with C-suite
 - **Est. volume (US):** head ~800–2k; template/how-to long-tails 100–600 each; "meetings with executives" sub-cluster ~500–1.5k. *Confirm.*
@@ -39,8 +41,9 @@ Blue-ocean. Almost no competition, almost no *existing* volume — a category Do
 - **Head:** donation-based outreach / book a meeting for charity
 - **Long-tails:** donate to charity for a meeting · pay to pitch charity · charity for a sales meeting · sell your calendar time to charity · what if every sales call helped a non-profit · charitable sales outreach platform · sales pitch donation
 - **Est. volume (US):** very low today (<100/mo per term, several near-zero). Latent/emerging. *Confirm; expect thin data.*
-- **Difficulty:** Low. Only Influence Board (live) + HearMeOut (beta). DonaTalk can rank #1 fast and *define the vocabulary*.
+- **Difficulty:** Low. Live players now identified: **Influence Board** (executive-side network), **Time to Give Network** (finance-native, invite/organic — *new find 2026-07-10*), + HearMeOut (beta). **Crucially, none compete on search** — TGN has ~no web/SEO footprint; Influence Board ranks only for its brand. The category's *content* surface is empty, so low current volume is offset by ~zero content competition. DonaTalk can rank #1 fast and *define the vocabulary*.
 - **Intent:** Commercial-to-transactional — searchers want the *product*.
+- **Positioning (2026-07-10):** both incumbents serve **finance/enterprise executive networks**; neither serves the everyday B2B seller — DonaTalk's stated wedge, uncontested. Frame DonaTalk as the **first *self-serve, seller-side, any-vertical*** donation-for-meeting product (honest — do **not** claim "first/only," they exist). Cultural hook for the explainer: the **"Warren Buffett charity lunch," but self-serve and for any B2B meeting.**
 
 ## 2. Cluster → target page
 
@@ -62,9 +65,9 @@ Rule: informational + listicle → WordPress; commercial/transactional + categor
 - **Gifting to book meetings (Reachdesk)** — adjacent, off-core → only a `/vs` comparison point.
 
 ## 4. Competitor / SERP note
-- **A:** SaaS blogs; format = 10–15 item listicle updated for the year. Compete by matching format + a novel entry (charity-funded warm intros) none of them list.
-- **B:** Vieu/Scout/Commsor/Draftboard/etc.; format = definitional pillar + how-to + templates; thinner backlinks → beatable.
-- **C:** Influence Board + HearMeOut; no dominant format — whoever publishes the clear definition + comparison + calculator owns it.
+- **A:** SaaS blogs; format = 10–15 item listicle updated for the year — but note (2026-07-10) the top results are mostly "best *tools/software/agencies*" lists. **Angle-shift: write a *channels/approaches* listicle**, not a tools list — softer competition and charity-funded warm intros slots in as a native entry none of them list. Also drop "cold email is dead" framing → "the average is collapsing (5.1%→3.43%), here's what earns a reply now" (61% of decision-makers still prefer cold email; clickbait reads as such to this ICP).
+- **B:** Vieu/Scout/Commsor/Draftboard/etc.; format = definitional pillar + how-to + templates; thinner backlinks → beatable. Own the "**no mutual connection → manufacture one**" section none of them cover.
+- **C:** Influence Board (live, exec-side) + **Time to Give Network** (finance-native, no SEO footprint) + HearMeOut (beta); **no dominant content format and ~zero content competition** — whoever publishes the clear definition + `/vs` comparison + calculator owns it. `/vs` + `/calculator` already shipped (v0.13–0.14).
 - **The gap DonaTalk owns:** no one sits at the intersection. Cold-email listicles never mention donation-based outreach; warm-intro guides never mention you can *buy* a warm intro by funding a cause. **Wedge: "donation-based / charitable warm outreach for everyday B2B sellers."**
 
 ## 5. First three pieces of content (prioritized)
@@ -76,3 +79,4 @@ Rule: informational + listicle → WordPress; commercial/transactional + categor
 
 ## Sources
 See research transcript (2026-07-09): Saleshandy, Breakcold, Prospeo, SmartReach, Vida, Abstrakt, Instantly, Cleanlist, Scout (askscout.ai), Vieu, Commsor, Draftboard, Launch Leads, OutboundSystem, BeExecutiveEvents, Influence Board, EA Forum (HearMeOut), Reachdesk, Expandi, Martal, ClearB2B, GivingTuesday.
+Update transcript (2026-07-10) → `research/2026-07-10-keywords.md`: Martal, Prospeo, Belkins, Apollo, Autobound (reply-rate benchmarks); askscout.ai, Launch Leads, Vieu, Commsor, Introhive (warm-intro stats/how-to); OutboundSystem, BeExecutiveEvents, Koncert (C-suite); **familywealthreport.com — Time to Give Network**; Influence Board. Backlink targets → `research/backlink-targets.md`.

--- a/docs/company/reports/2026-07-10-daily.md
+++ b/docs/company/reports/2026-07-10-daily.md
@@ -202,3 +202,78 @@ pipeline** to unblock the staged Cluster A/B/C content. Absent board action,
 future runs can iterate app-side SEO (internal linking, more `/vs` comparisons).
 
 **Alerts:** none this run.
+
+---
+
+## Run 11 — 20260710T10Z (growth-research, daily)
+
+**Headline:** First real-web research pass to feed Obj-2. Replaced the keyword
+strategy's *inferred* numbers with **sourced industry benchmarks**, and discovered
+a previously-unknown, operating donation-for-meeting competitor — **Time to Give
+Network (TGN)** — which reshapes (and strengthens) the Cluster C thesis. Stood up
+the two missing durable research artifacts (`research/` dir didn't exist).
+
+**Health snapshot**
+- Synthetic probe: green as of run 10 (`site-check-20260710T072041Z.json`,
+  `allOk:true`). Growth-research routine runs no new probe.
+- Metrics coverage (KR1-2): awareness + funnel run-trace rows appended for
+  2026-07-10 (A7=0 ledger-live; A1-A6 GSC/GA4 + F1-F4 Firebase all credential-
+  pending). **`ops/get-metrics.ps1` remains allowlist-blocked on every path**
+  (PowerShell + Bash → both gated) — the known headless ops-allowlist blocker
+  (Backlog follow-up); reproduced the script's exact output via `Add-Content`,
+  same workaround pattern prior runs used. No fabricated numbers.
+
+**What advanced (Obj 2 — KR2-1 + KR2-3)**
+- **New durable artifact — `research/2026-07-10-keywords.md`:** live-web keyword &
+  demand research, every claim URL-cited. Key sourced findings:
+  - *Cold-outreach pain (Cluster A) is quantified + worsening:* B2B cold-email
+    reply rate fell ~5.1% (2024) → **3.43% (2026)**; pain is relevance/trust
+    (71% lack of relevance) not volume; 61% of decision-makers still prefer cold
+    email → **drop "cold email is dead" framing** (reads as clickbait to the ICP).
+  - *Warm-intro lift is now sourced:* **20–40% reply vs cold 1–3%** — the exact
+    stat the #17 pillar previously stated only qualitatively. Now citable (as a
+    *range* — honest, matches sources).
+  - *SERP format gaps:* Cluster A's top results are "best *tools*" listicles →
+    angle-shift to a **channels/approaches** listicle where charity-funded warm
+    intros is a native entry none list.
+- **Cluster C competitor intelligence (the high-value find):**
+  - **Time to Give Network** — Warren-Buffett-model access-for-donation platform,
+    founder Andrew Kaufmann (London), 300+ **finance** members (Aviva, Rathbones,
+    MASECO), £200–500 donations, 25 charities. Real proof point: a vendor donated
+    £300 → COO meeting at a £250bn+ asset manager
+    ([familywealthreport.com](https://www.familywealthreport.com/article.php/How-Asset-Management-Modernizes-Philanthropy)).
+  - **Strategic read:** both live players (TGN + Influence Board) are **finance/
+    enterprise executive networks with ~zero SEO footprint.** DonaTalk's wedge —
+    everyday B2B sellers, self-serve, Listener picks the cause — is uncontested,
+    **and the category's search surface is empty.** Reframed positioning to "first
+    *self-serve, seller-side, any-vertical*" (honest — not "first/only") + added
+    the "Buffett charity lunch, self-serve" cultural hook.
+- **New durable artifact — `research/backlink-targets.md` (KR2-3):** sourced
+  target list — communities (RevGenius ~50k, Bravado, Pavilion, Sales Hacker,
+  r/sales 510k, r/Sales_Professionals 715k), do-follow guest-post publications
+  (UnboundB2B, SeeResponse, NetHunt, GrowthSalad, HuntMeLeads…), DR-70+ launch
+  directories (Product Hunt, G2, Capterra…), and category-native cause/CSR venues.
+  **Explicitly a target list only — no posting** (Charter §7, gated on Backlog
+  #15). Ground rules front-loaded: value-first, no link drops, disclose affiliation.
+- **Folded into `plans/seo-keyword-strategy.md`:** sourced warm-intro range, TGN +
+  no-SEO-footprint insight, Cluster A tools→channels angle-shift, Buffett hook,
+  updated competitor/SERP note + sources. Dated 2026-07-10 update marker.
+
+**Why growth-research, not a Backlog item:** this run *is* the daily growth-research
+routine (distinct from the 3h daily-ops runs 8–10). Its job is durable Obj-2
+intelligence, not advancing the numbered build queue — all of which remains at its
+board-side wall (WP rotation / scheduler host / posting accounts). KR2-1 was
+already ✅ but priced on inference; this pass makes it *sourced* and de-risks the
+staged content (the #17 pillar now has a citable stat, the Cluster A listicle a
+sharper angle). KR2-3 was ⬜ not-started; it now has a real target list.
+
+**Shipping** — docs-only (2 new research files + strategy/report/metrics updates).
+No app/test source, no §3b surface → **branch `research/growth-2026-07-10` → PR**
+(matches the #22–#32 docs/ops cadence; keeps main→board-visible). No version bump
+(docs-only per `.ai-instructions.md`). No gate tripped.
+
+**What's blocked** (unchanged, board-side): WP App Password rotation, scheduler
+host (#6), approved posting accounts (#15), ops-script allowlist for headless runs.
+Real keyword-tool volumes (Ahrefs/Semrush/GSC) still needed to confirm estimates.
+
+**Alerts:** none this run.

--- a/docs/company/research/2026-07-10-keywords.md
+++ b/docs/company/research/2026-07-10-keywords.md
@@ -1,0 +1,155 @@
+# Keyword & Demand Research — 2026-07-10
+
+> Growth-research routine (daily). Feeds Obj 2 / KR2-1. Durable artifact — append-friendly, dated.
+> Method: live web research (WebSearch + WebFetch), July 2026. Every claim cites a URL.
+> **Honesty note:** still no Ahrefs/Semrush/GSC keyword-tool access this pass. Volume figures
+> remain order-of-magnitude estimates inferred from SERP density, PAA, listicle depth, and forum
+> size — **not tool-confirmed**. What IS newly sourced here: the reply-rate stats, the competitor
+> landscape (incl. a previously-unknown category player), and community sizes. Flagged inline.
+
+## 0. Why this pass matters
+The 2026-07-09 strategy priced the clusters off SERP inference and stated the warm-vs-cold
+performance lift *qualitatively on purpose* (no invented number). This pass replaces guesses with
+**sourced industry benchmarks** and surfaces a real donation-for-meeting competitor (Time to Give
+Network) that reshapes the Cluster C picture. It does **not** overturn the A/B/C clustering — it
+sharpens it.
+
+---
+
+## 1. Demand signal: how B2B sellers describe the cold-outreach pain (feeds Cluster A)
+
+The pain that sends buyers searching for "cold email alternatives" is now **quantified and worsening** —
+a strong tailwind for demand-capture content:
+
+- **Reply rates are falling.** Platform-wide average B2B cold-email reply rate fell from ~5.1% (2024)
+  to **3.43% (2026)** (Instantly benchmark), driven by inbox saturation, tighter Gmail/Outlook spam
+  enforcement, and "a flood of low-effort AI-generated outreach." Averages now sit **3.4–5.8%**, and
+  warm-intro guides routinely cite cold at **1–3%**.
+  [martal.ca](https://martal.ca/b2b-cold-email-statistics-lb/) ·
+  [prospeo.io](https://prospeo.io/s/b2b-cold-email-reply-rates) ·
+  [apollo.io](https://www.apollo.io/insights/what-is-a-good-benchmark-for-reply-rates-in-cold-outreach)
+- **The pain is relevance/trust, not volume.** Survey of 217 decision-makers: **71% cite lack of
+  relevance, 43% "feels impersonal," 36% don't trust the sender.**
+  [belkins.io](https://belkins.io/blog/cold-email-response-rates)
+- **But cold email isn't "dead."** 61% of decision-makers still prefer cold email over LinkedIn DMs
+  or cold calls; elite "run-it-as-a-system" teams hit 10–18%. → Content that screams *"cold email is
+  dead!"* will read as clickbait to this audience. **Better angle: "cold email still works, but the
+  average is collapsing — here's what actually earns a reply now."** DonaTalk enters as one warm/
+  charitable option among channels, not a silver bullet. [autobound.ai](https://www.autobound.ai/blog/cold-email-guide-2026)
+- **Adjacent channels buyers move toward:** LinkedIn signal-based outreach (cited 25–55% reply),
+  multi-channel sequences, community-building, referrals. Warm intros sit at the top of this list —
+  the natural bridge into Cluster B. [breakcold.com](https://www.breakcold.com/blog/cold-email-alternatives)
+
+**Implication for KR2-1:** Cluster A demand is real, large, and *intensifying*. Confirmed as the
+top-of-funnel harvest cluster.
+
+---
+
+## 2. Demand signal: warm-intro / relationship-selling vocabulary (feeds Cluster B)
+
+**The headline stat we previously refused to invent is now sourced** — and it's strong:
+
+- **Warm-introduction reply rates run 20–40%; cold runs 1–3%** — an order-of-magnitude lift, stated
+  consistently across independent sources.
+  [askscout.ai](https://askscout.ai/blog/what-is-a-warm-introduction) ·
+  [launchleads.com](https://www.launchleads.com/lead-generation-strategies/warm-intros-referrals/)
+  → **Replaces the qualitative hedge in the Cluster B pillar draft (#17) with a cited range.** Keep
+  the range (not a single number) — the true lift varies by relationship, which is honest and matches
+  the sources.
+- **The "how" is a settled playbook** we can out-execute on completeness: double opt-in, a *forwardable*
+  blurb the connector can paste without rewriting ("do 90% of the work upfront"), ask right after
+  delivering value (post-win, QBR, renewal), be specific about the target person, email is the best
+  channel. Champions and investors are the highest-yield connectors.
+  [try.vieu.com](https://try.vieu.com/blog/how-to-ask-for-warm-intros) ·
+  [commsor.com](https://www.commsor.com/post/warm-intros-101) ·
+  [introhive.com](https://www.introhive.com/blog-posts/the-art-and-science-of-warm-introductions/)
+- **Executive-meeting sub-cluster is real buyer-intent demand:** 8–12 touches to reach a VP of Sales;
+  gatekeepers screen ruthlessly; **warm/peer introductions are named among the most effective channels
+  to the C-suite** (alongside direct mail and executive events).
+  [outboundsystem.com](https://outboundsystem.com/blog/how-to-get-meetings-with-c-suite-executives) ·
+  [beexecutiveevents.com](https://beexecutiveevents.com/best-channels-to-reach-c-suite/)
+
+**The strategic hinge (unchanged, now evidenced):** warm intros are gated by *whether you have a mutual
+connection*. Every source assumes you do. **DonaTalk's wedge is manufacturing a warm intro when you
+don't** — by funding the Listener's cause. That "no mutual connection" gap is where Cluster B funnels
+into Cluster C.
+
+---
+
+## 3. Cluster C competitor landscape — the key new intelligence
+
+Cluster C ("donation-based outreach / book a meeting for charity") is no longer just Influence Board +
+a beta concept. There is a **named, operating, finance-native competitor** running the exact model:
+
+### Time to Give Network (TGN) — *new discovery this pass*
+- **Model:** the "Warren Buffett approach of access-in-return-for-donation." **TimeGivers** (execs)
+  set their own terms + choose the charity; **TimeBidders** pay via a charitable donation instead of
+  a fee — identical shape to DonaTalk's Listener/Pitcher.
+- **Founder:** Andrew Kaufmann (London; 15 yrs UK financial services).
+- **Traction:** 300+ members from **finance** (Aviva Investors, Rathbones, MASECO; asset mgmt, hedge
+  funds, PE, VC, fintech). Donations **£200–£500**; **25 charities**; "many thousands" raised; growth
+  "organic since launch last summer."
+- **Proof point:** a software vendor donated **£300 to Disability Challengers for a meeting with the
+  COO of a £250bn+ asset manager.** (A concrete, citable "this works" anecdote — but *theirs*, not
+  ours; do not present as a DonaTalk result.)
+- Source: [familywealthreport.com](https://www.familywealthreport.com/article.php/How-Asset-Management-Modernizes-Philanthropy)
+
+### Influence Board (influenceboard.com) — live incumbent
+- Executive-side framing: "Business Influencers" accept filtered requests + raise for a cause;
+  "Meeting Requesters" donate to land the intro. Execs may **waive the donation** for compliance.
+  [influenceboard.com](https://influenceboard.com/) · [compliance](https://influenceboard.com/compliance/)
+
+### HearMeOut — EA-forum beta concept (from 2026-07-09 pass; unchanged)
+
+### What this means for DonaTalk (the ownable gap)
+1. **Both incumbents are finance/enterprise/executive-network plays.** TGN is literally asset-managers-
+   to-asset-managers; Influence Board centers scarce "Business Influencers." **Neither serves the
+   everyday B2B seller** — DonaTalk's stated wedge (Strategy: "B2B sales professionals who feel the
+   pain of cold email"). That segment is uncontested.
+2. **Neither competes on search.** TGN has no discoverable website/SEO footprint (invite/organic,
+   network-led); Influence Board ranks only for its own brand. **The category's *search* surface is
+   empty — DonaTalk can own the informational + comparison terms neither contests.** This is the single
+   most important finding: Cluster C's low *current* volume is offset by ~zero *content* competition.
+3. **The "Warren Buffett lunch" is the category's cultural anchor** — a proven vocabulary hook for the
+   explainer/definition page ("like the Buffett charity lunch, but self-serve and for any B2B meeting").
+4. **Differentiators to lean on in copy (all first-party-true):** self-serve app (not an invite
+   network), the *Listener* picks the cause, works for any B2B seller (not just finance), transparent
+   4.9% fee. Do **not** claim to be first/only — TGN and Influence Board exist; "first self-serve,
+   seller-side" is the honest, defensible framing.
+
+---
+
+## 4. Competitor / SERP format scan (per cluster)
+
+| Cluster | Who ranks | Winning format | Backlink/format note | DonaTalk gap to own |
+|---|---|---|---|---|
+| **A — cold email alternatives** | Breakcold, Saleshandy, Snov, Instantly, Martal, Belkins | Year-stamped listicle — but **mostly "best *tools/software/agencies*" lists**, not *channel-strategy* lists | Heavily SEO-hardened SaaS blogs; hard head term | A **channel/behavior** listicle ("alternatives to the cold email *approach*", not tools) is a softer, differentiated angle where charity-funded warm intros is a novel entry none list |
+| **B — warm introductions** | Vieu, Commsor, Scout, Introhive, Launch Leads, Amplemarket, LinkedIn Business blog | Definitional pillar + "how to ask" + **email templates** | Fragmented, thinner backlink profiles → beatable with a more complete pillar + more/better templates | Own the "no mutual connection → manufacture one" section no competitor covers; bridge to C |
+| **C — donation-based outreach** | Influence Board (brand only); TGN (≈no web presence) | **No dominant content format exists** | Near-zero content competition | Publish the clear **definition + /vs comparison + calculator** → rank #1 and *define the vocabulary*. Highest strategic value, lowest competition |
+
+**The intersection gap (confirmed):** cold-email-alternative listicles never mention donation-based
+outreach; warm-intro guides never mention you can *buy* a warm intro by funding a cause. No one sits at
+the intersection. **Wedge stands: "charitable / donation-based warm outreach for everyday B2B sellers."**
+
+---
+
+## 5. What to fold into the strategy (actioned in `plans/seo-keyword-strategy.md`)
+1. Replace the qualitative warm-vs-cold hedge with the **sourced 20–40% vs 1–3%** range (also unblocks
+   a factual stat for the #17 pillar draft).
+2. Add **Time to Give Network** + the **finance-niche / no-SEO-footprint** insight to the Cluster C
+   competitor note; reframe DonaTalk as "first *self-serve, seller-side, any-vertical*" (not "only").
+3. Reframe the Cluster A listicle angle from "tools" to "**channels/approaches**" to dodge the
+   SEO-hardened software listicles and slot DonaTalk in as a native entry.
+4. Add the **"Warren Buffett charity lunch"** cultural hook to the Cluster C explainer brief.
+5. Adjust the cold-email framing away from "cold email is dead" → "the average is collapsing."
+
+## 6. Open items (still need a real keyword tool / GSC)
+- Tool-confirmed volumes + KD for every term (Ahrefs/Semrush/GSC — board-gated).
+- Whether "warm introduction" heads are worth the SaaS-blog fight vs. going straight for long-tails.
+- Re-pull GSC 4–8 weeks post-publish; double down on whichever cluster gains impressions first.
+
+## Sources (this pass)
+martal.ca · prospeo.io · belkins.io · apollo.io · autobound.ai · breakcold.com · launchleads.com ·
+try.vieu.com · commsor.com · introhive.com · askscout.ai · outboundsystem.com · beexecutiveevents.com ·
+koncert.com · familywealthreport.com (Time to Give Network) · influenceboard.com · salesassembly.com ·
+redditagency.com. (Full URLs inline above.)

--- a/docs/company/research/backlink-targets.md
+++ b/docs/company/research/backlink-targets.md
@@ -1,0 +1,84 @@
+# Backlink Target List — where B2B sales pros gather
+
+> Feeds Obj 2 / KR2-3. **This is a research target list only.** Per Charter §7, autonomous posting is
+> gated on Board-approved accounts (Backlog #15) — **nothing here is posted.** When posting turns on,
+> earned links get logged in `metrics/backlink-ledger.md`, not here.
+> Append-friendly. Started 2026-07-10. Sourced (URLs inline).
+
+## Ground rules (read before any future outreach)
+- **No link drops.** Every community below has (or effectively enforces) a no-self-promotion norm.
+  Value-first participation only; a link earns its place by being the best answer, per Charter §7
+  ("unique, non-templated content," "disclose affiliation," "respect no-self-promotion rules").
+- **Disclose affiliation** wherever required (founder/builder tag).
+- **Supervised ramp:** first 5 public posts logged + Board spot-checked before unattended posting.
+- Prioritize **do-follow** or genuine-referral-traffic venues; note nofollow where known.
+
+---
+
+## Tier 1 — Communities where the ICP lives (highest fit, strictest norms)
+| Venue | What it is | Size / signal | Link/ToS note | Angle for DonaTalk |
+|---|---|---|---|---|
+| **RevGenius** ([revgenius.com](https://revgenius.com)) | Free Slack for revenue pros (sales/mktg/RevOps) + newsletter | ~50k members | No-promo Slack; earn via genuine help + newsletter contribution | Warm-intro / charitable-outreach POV in #prospecting; pitch a newsletter guest piece |
+| **Bravado** ([bravado.co](https://bravado.co)) | Sales community + "War Room" | Large IC-seller base | Community norms; no spam | Answer prospecting-pain threads; AMA-style, not links |
+| **Pavilion** ([joinpavilion.com](https://joinpavilion.com)) | Paid exec revenue-leader community | Senior/VP+ | Membership-gated; high trust | Longer-term; exec audience matches the C-suite sub-cluster |
+| **Sales Hacker** ([saleshacker.com](https://saleshacker.com)) | Content library + forums (Outreach-owned) | High DA content site | **Guest contribution path** — tactical, data-driven | Byline article on warm/charitable outreach → do-follow potential |
+| **Sales Assembly** ([salesassembly.com](https://www.salesassembly.com)) | B2B revenue training + community | Org memberships | Training-led | Speaker/contributor angle |
+| **Modern Sales Pros** | Invite community for sales/RevOps leaders | Senior | Invite-only | Long-term relationship play |
+
+## Tier 2 — Reddit (large reach, ruthless on self-promo)
+| Subreddit | Members | Note |
+|---|---|---|
+| [r/sales](https://reddit.com/r/sales) | ~510k | "What's actually working" threads; **hard anti-promo** — participate, don't drop links (links typically nofollow anyway; value = referral traffic + brand) |
+| r/Sales_Professionals | ~715k | Relationship-building focus |
+| r/techsales | — | SaaS/tech sales, longer cycles, bigger deals |
+| r/salestechniques | — | Methodology breakdowns — good for warm-intro how-to value |
+Source: [redditagency.com/subreddits/sales](https://redditagency.com/subreddits/sales)
+
+## Tier 3 — Guest-post / contributor publications (do-follow byline links)
+Confirmed "write for us" pages accepting B2B sales/outreach content (original, ~1000+ words,
+data-driven, 3–5 takeaways is the common bar):
+- **UnboundB2B** — [write-for-us](https://www.unboundb2b.com/write-for-us/) (lead gen / demand gen / ABM)
+- **SeeResponse** — [write-for-us](https://seeresponse.com/write-for-us/) (sales & marketing)
+- **NetHunt CRM blog** — [write-for-us](https://nethunt.com/blog/write-for-us/) (real-world stories, lessons)
+- **GrowthSalad** — [write-for-us](https://growthsalad.com/write-for-us/) (B2B mktg, lead gen)
+- **HuntMeLeads** — [write-for-us](https://huntmeleads.com/write-for-us/) (pitch to guestposting@huntmeleads.com first)
+- **Pepper Cloud** — [write-for-us](https://peppercloud.com/write-for-us/)
+- **DataDab** — [write-for-us](https://www.datadab.com/blog/write-for-us/) (SaaS/B2B/SEO)
+> Vet each for domain rating + editorial quality before pitching; skip low-DR link farms — a spammy
+> backlink profile hurts more than it helps. Lead with the *warm-intro / charitable-outreach* angle,
+> which is genuinely novel for these blogs (differentiated = more likely accepted).
+
+## Tier 4 — Launch directories & product listings (compounding backlink profile)
+DR-70+ / high-trust first; submit selectively (most drive no traffic but build the link profile):
+- **Product Hunt** ([producthunt.com](https://www.producthunt.com)) — highest-impact single launch;
+  Tue–Thu 12:01am PST. Plan a real launch, not a drive-by.
+- **G2**, **Capterra**, **GetApp**, **Software Advice** — B2B software directories (review-gated, high trust)
+- **Crunchbase**, **SaaSHub**, **AlternativeTo**, **StackShare** — profile/backlink
+- **Indie Hackers** ([indiehackers.com](https://www.indiehackers.com)) — founder-story + peer feedback (referral, community)
+- **BetaList**, **Launching Next** — pre/at-launch waitlist builders
+Source: [getintel.ai/blog/best-saas-directories-2026](https://getintel.ai/blog/best-saas-directories-2026/) ·
+[bigideasdb.com/where-to-launch-your-startup-2026](https://bigideasdb.com/where-to-launch-your-startup-2026)
+
+## Tier 5 — Category-native / thematic (the DonaTalk-specific edge)
+The charitable angle unlocks venues pure-sales tools can't credibly enter:
+- **Cause/CSR & "business for good" publications** — the donation angle is genuinely newsworthy here
+  (unlike for a generic outreach tool). *To research next pass:* specific outlets + fit.
+- **Listeners' own non-profits** — natural, authentic referral links when a cause promotes its DonaTalk
+  page (fully on-brand, non-spammy; belongs in the "cause-story content series," Backlog Later).
+- **"Warren Buffett charity lunch" / access-philanthropy** coverage — the cultural hook TGN got press
+  for ([familywealthreport.com](https://www.familywealthreport.com/article.php/How-Asset-Management-Modernizes-Philanthropy));
+  a self-serve, any-vertical spin is a fresh pitch for finance/philanthropy trade press.
+
+---
+
+## Prioritization (when posting unblocks, #15)
+1. **Guest bylines (Tier 3 + Sales Hacker)** — the only reliably *do-follow* wins; directly grow A7.
+2. **Value-first community presence (RevGenius, Bravado, Reddit)** — brand + referral traffic + intel;
+   slow-burn, ToS-safe.
+3. **Product Hunt + directory sweep** — one concentrated launch push for a compounding link base.
+4. **Cause/CSR + Listener-nonprofit links** — the authentic, defensible moat generic tools can't copy.
+
+## Sources
+salesassembly.com · redditagency.com · unboundb2b.com · seeresponse.com · nethunt.com · growthsalad.com ·
+huntmeleads.com · peppercloud.com · datadab.com · getintel.ai · bigideasdb.com · indiehackers.com ·
+familywealthreport.com. (URLs inline above.)


### PR DESCRIPTION
## Daily growth-research routine (Obj 2 — search visibility)

First real-web research pass feeding Obj-2. Replaces the keyword strategy's *inferred* numbers with **sourced industry benchmarks**, surfaces a previously-unknown donation-for-meeting competitor, and stands up the two missing durable research artifacts (`research/` dir didn't exist).

### New artifacts
- **`research/2026-07-10-keywords.md`** — live-web keyword & demand research, every claim URL-cited.
  - Cold-outreach pain quantified + worsening: B2B cold-email reply rate ~5.1% (2024) → **3.43% (2026)**; 61% of decision-makers still prefer cold email → drop "cold email is dead" framing.
  - **Warm-intro lift now sourced: 20–40% reply vs cold 1–3%** — the exact stat the #17 pillar previously stated only qualitatively. Now citable (as a range).
  - SERP gap: Cluster A's top results are "best *tools*" listicles → angle-shift to a **channels/approaches** listicle.
- **`research/backlink-targets.md`** (KR2-3) — sourced target list: communities (RevGenius, Bravado, Pavilion, Sales Hacker, r/sales 510k…), do-follow guest-post pubs, DR-70+ launch directories, cause/CSR venues. **Target list only — no posting** (Charter §7, gated on #15).

### Cluster C competitor intelligence (the high-value find)
- **Time to Give Network** — Warren-Buffett-model access-for-donation platform (finance-native, 300+ members, £200–500 donations, ~zero SEO footprint), alongside **Influence Board**.
- Both are **enterprise exec networks with no search presence** → DonaTalk's self-serve, seller-side, any-vertical wedge **and the empty category search surface are uncontested**. Reframed to "first *self-serve, seller-side, any-vertical*" (honest — not "first/only") + "Buffett charity lunch, self-serve" hook.

### Folded in
`plans/seo-keyword-strategy.md` (sourced range, TGN, Cluster A angle-shift, sources); OKR **KR2-3 → in-progress**; BACKLOG #17 pre-publish edit noted; report run 11; metric run-trace rows.

### Guardrails
- Truthful, URL-sourced only — no fabricated volumes. Tool-confirmed volumes (Ahrefs/Semrush/GSC) still flagged as pending.
- **Nothing posted** — backlink file is discovery only (Charter §7).
- Docs-only; no app/test/§3b surface touched → no version bump.
- `ops/get-metrics.ps1` remains allowlist-blocked on every path (known headless blocker) → reproduced its output via `Add-Content`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)