### PR TITLE
content(seo): sourced warm-vs-cold reply-rate range in Cluster B pillar (#17)

### DIFF
--- a/docs/company/BACKLOG.md
+++ b/docs/company/BACKLOG.md
@@ -2,7 +2,7 @@
 
 > Ordered work queue. Each scheduled run advances the top **unblocked** item.
 > Status: ⬜ todo · 🟡 in progress · ✅ done · 🔴 BLOCKED
-> Last updated: 2026-07-10 (run 11 — growth-research)
+> Last updated: 2026-07-10 (run 12 — warm-intro pillar sourced-stat edit)
 
 ## Now (Obj 1 — the machine)
 | # | Item | KR | Status |
@@ -34,8 +34,8 @@
 ## Now (Obj 2 — content engine)
 | # | Item | KR | Status |
 |---|------|----|--------|
-| 16 | Cluster A listicle — "cold email alternatives" (`donatalk.com/blog/`) | 2-1→2-3 | 🟡 drafted `docs/company/content/cold-email-alternatives.md` (publish-ready, brand-voice, Sec 6-truthful). **Publish blocked:** WP App Password pending rotation + publish pipeline (item 14) unbuilt |
-| 17 | Cluster B pillar + template — "how to get warm introductions" | 2-1→2-3 | 🟡 drafted `docs/company/content/how-to-get-warm-introductions.md` (run 8): definitional pillar + how-to (double opt-in ask) + 2 original copy-paste templates (ask-connector + forwardable blurb) + exec sub-cluster + FAQ; bridges to Cluster C via donation-based outreach for the "no mutual connection" case. Brand-voice, Sec-6 truthful (warm-vs-cold stated qualitatively, ~1% flagged to confirm). **Publish blocked:** WP App Password rotation + pipeline (items 14/14b). **Pre-publish edit ready (run 11):** swap the qualitative hedge for the now-sourced **warm-intro 20–40% vs cold 1–3%** range (`research/2026-07-10-keywords.md`) — keep as a range, honest. |
+| 16 | Cluster A listicle — "cold email alternatives" (`donatalk.com/blog/`) | 2-1→2-3 | 🟡 drafted `docs/company/content/cold-email-alternatives.md` (publish-ready, brand-voice, Sec 6-truthful). **Publish blocked:** WP App Password pending rotation + publish pipeline (item 14) unbuilt. **Pre-publish edit pending (from research §5.5):** reframe the flat "~1%" cold hook to the sourced "average is collapsing" framing (Instantly: 5.1%→3.4%, 2026) + confirm the channels-not-tools angle; deferred (touches the article's central hook + the brand's ~1% figure — a positioning call, not a mechanical stat swap). |
+| 17 | Cluster B pillar + template — "how to get warm introductions" | 2-1→2-3 | 🟡 drafted `docs/company/content/how-to-get-warm-introductions.md` (run 8): definitional pillar + how-to (double opt-in ask) + 2 original copy-paste templates (ask-connector + forwardable blurb) + exec sub-cluster + FAQ; bridges to Cluster C via donation-based outreach for the "no mutual connection" case. Brand-voice, Sec-6 truthful. **Pre-publish edit DONE (run 12):** qualitative hedge swapped for the sourced **warm-intro 20–40% vs cold 1–3%** range (intro, vs-table, note-block, FAQ, editorial note) — kept as a range per `research/2026-07-10-keywords.md`; editorial note flags platform-avg cold (~3.4%) vs the 1–3% warm-comparison framing. Draft now stat-final. **Publish still blocked:** WP App Password rotation + pipeline (items 14/14b). |
 | 18 | Cluster C explainer + app `/vs` page — "donation-based outreach" | 2-1→2-3 | 🟡 **`/vs` shipped+merged (v0.13.0, PR #29, run 7)** + **impact calculator shipped (v0.14.0, run 9):** `app/calculator/page.tsx` (server: metadata + WebApplication/Breadcrumb/FAQPage JSON-LD) + `OutreachCalculator.tsx` (client: target meetings × donation × editable ~1% reply rate → monthly donation impact, 4.9% fee cost, all-in cost/meeting, cold-message volume). All outputs = arithmetic on visitor input (no invented metrics, Sec 6); in sitemap; cross-links to `/vs` + `/listeners`. tsc clean, 598 unit tests green, non-§3b. Remaining: thin WP `what-is-donation-based-outreach` explainer (WP-publish-blocked, item 14b) |
 | 14b | WordPress publish pipeline: markdown draft → WP REST draft post (reads creds from env) | 2-2 | ⬜ todo — **gate on WP App Password rotation first** |
 

--- a/docs/company/content/how-to-get-warm-introductions.md
+++ b/docs/company/content/how-to-get-warm-introductions.md
@@ -24,8 +24,8 @@ Every experienced seller eventually arrives at the same conclusion: the fastest
 path to a meeting isn't a better cold email — it's not being cold at all.
 
 A cold email lands in front of a stranger and asks for their time before you've
-earned a second of it. The average reply rate reflects that: **around 1%.** A
-**warm introduction** starts from the opposite place. Someone the prospect
+earned a second of it. The reply rate reflects that: warm-intro guides consistently
+peg cold outreach at **1–3%.** A **warm introduction** starts from the opposite place. Someone the prospect
 already trusts hands you their attention. You skip the "who are you and why
 should I care?" phase entirely, because a person they respect just answered it
 for you.
@@ -67,7 +67,7 @@ conversation — but they start from opposite levels of trust.
 |---|---|---|
 | **Starting trust** | Zero — you're a stranger | Borrowed from the connector |
 | **First question in their head** | "Who is this and why should I care?" | "My contact vouched for them — worth a look" |
-| **Typical reply rate** | ~1% on cold email | Dramatically higher (varies by source & relationship) |
+| **Typical reply rate** | ~1–3% on cold email | ~20–40% (varies by relationship & source) |
 | **Scales by** | Volume | Relationships |
 | **Main limit** | Ignored at scale | You run out of warm intros |
 
@@ -75,11 +75,11 @@ The pattern underneath every high-performing outreach method is the same:
 **manufacture a reason to say yes before the ask.** Warm intros do it with borrowed
 trust. That's the whole advantage — and, as we'll see, also the whole limitation.
 
-> A note on numbers: the ~1% cold-email figure is widely cited and used in
-> DonaTalk brand materials. Warm introductions convert meaningfully better, but
-> the exact lift depends heavily on relationship strength and source — so we
-> describe it qualitatively rather than quote a single percentage. Confirm any
-> specific stat against a current, citable source before repeating it.
+> A note on numbers: independent warm-intro guides consistently put warm-
+> introduction reply rates at **20–40%**, versus **1–3%** for cold outreach — an
+> order-of-magnitude lift. We quote it as a range on purpose: the true lift varies
+> with relationship strength and source, so a single headline number would claim a
+> precision the data doesn't support. (Sources: askscout.ai, launchleads.com.)
 
 ## How to ask for a warm introduction (without being awkward)
 
@@ -222,8 +222,9 @@ gives an easy out. Making the intro effortless to give is what gets it given.
 
 **Warm intro vs cold outreach — which is better?**
 Warm introductions convert far better because they start from trust rather than
-from zero. Cold outreach scales on volume but is easy to ignore; warm intros are
-harder to ignore but limited by the size of your network.
+from zero — independent guides put warm-intro reply rates around **20–40%** versus
+**1–3%** for cold outreach. Cold outreach scales on volume but is easy to ignore;
+warm intros are harder to ignore but limited by the size of your network.
 
 **What if I don't have a mutual connection?**
 Warm intros run out because your network is finite. When there's no shared contact,
@@ -240,10 +241,12 @@ exchange for an opt-in conversation.
 
 *Editorial note (staging): First-party claims (mechanism, 4.9% fee, Pitcher/
 Listener model, "prospect picks the cause") are accurate to the DonaTalk product.
-The ~1% cold-email response figure is industry-cited and used in DonaTalk brand
-assets; confirm the current published source before go-live. The relative
-performance of warm intros over cold outreach is stated qualitatively on purpose —
-do not attach a specific percentage without a citable source. Third-party methods
-are described at the category level to stay truthful and non-defamatory per Charter
-Sec 6. The two templates are original. Do not publish until the WordPress App
-Password is rotated and the publish pipeline (Backlog item 14/14b) is built.*
+The warm-intro (20–40%) vs cold (1–3%) reply-rate figures are cited as a range from
+independent guides (askscout.ai, launchleads.com) — kept as a range on purpose
+because the true lift varies by relationship; do not collapse to a single number.
+Note platform-wide cold-email averages run somewhat higher (~3.4% in 2026); the
+1–3% here is the warm-vs-cold comparison framing those guides use, which is the apt
+contrast for this page. Third-party methods are described at the category level to
+stay truthful and non-defamatory per Charter Sec 6. The two templates are original.
+Do not publish until the WordPress App Password is rotated and the publish pipeline
+(Backlog item 14/14b) is built.*

--- a/docs/company/metrics/awareness-log.csv
+++ b/docs/company/metrics/awareness-log.csv
@@ -10,3 +10,4 @@ date_utc,A1,A2,A3,A4,A5,A6,A7,note
 2026-07-10,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger
 2026-07-10,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger
 2026-07-10,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger (growth-research run)
+2026-07-10,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger

--- a/docs/company/metrics/funnel-log.csv
+++ b/docs/company/metrics/funnel-log.csv
@@ -10,3 +10,4 @@ date_utc,F1,F2,F3,F4,R1,note
 2026-07-10,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account
 2026-07-10,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account
 2026-07-10,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account (growth-research run)
+2026-07-10,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account

--- a/docs/company/metrics/ops-health-log.csv
+++ b/docs/company/metrics/ops-health-log.csv
@@ -14,3 +14,4 @@ ts_utc,run_type,H1,H2,H3,H4,note
 20260710T072041Z,probe,success,none,pass,not-run,critical-path probe
 20260710T072238Z,probe,success,none,pass,not-run,critical-path probe
 20260710T100005Z,probe,success,none,pass,not-run,critical-path probe
+20260710T102039Z,probe,success,none,pass,not-run,critical-path probe

--- a/docs/company/reports/2026-07-10-daily.md
+++ b/docs/company/reports/2026-07-10-daily.md
@@ -277,3 +277,60 @@ host (#6), approved posting accounts (#15), ops-script allowlist for headless ru
 Real keyword-tool volumes (Ahrefs/Semrush/GSC) still needed to confirm estimates.
 
 **Alerts:** none this run.
+
+---
+
+## Run 12 — 20260710T1020Z (daily-ops, every-3h)
+
+**Headline:** Folded run-11's sourced benchmark into the Cluster B pillar
+(Backlog #17): swapped the deliberately-qualitative warm-vs-cold hedge for the
+now-cited **warm-intro 20–40% vs cold 1–3%** range across five locations. Draft is
+now stat-final; still WP-publish-blocked. Obj-1 machine work remains at its
+autonomous ceiling (board-side blockers).
+
+**Health snapshot**
+- Synthetic probe: **green** — newest artifact `site-check-20260710T102039Z.json`,
+  `allOk:true`, `/`, `/listeners`, `/login` all 200.
+- Metrics coverage (KR1-2, runner-collected this run): ops-health
+  `20260710T102039Z,probe,success,none,pass` appended; awareness `A1-A6 n/a`
+  (GSC/GA4 creds pending) / `A7=0` (empty ledger); funnel `F1-F4/R1 n/a`
+  (Firebase Admin pending). No fabricated numbers.
+
+**What advanced (Obj 2 — KR2-1)**
+- **Backlog #17 pre-publish edit → DONE:** the warm-intro pillar previously stated
+  the warm-vs-cold lift qualitatively on purpose (no invented number). Run 11's
+  growth-research sourced the real figure (askscout.ai, launchleads.com), so this
+  run applied it to `docs/company/content/how-to-get-warm-introductions.md`:
+  - intro line: cold framed as **1–3%** (warm-intro-guide framing) instead of a
+    flat "~1%";
+  - warm-vs-cold comparison table: reply-rate row now **~1–3% cold / ~20–40% warm**;
+  - the "note on numbers" block: replaced the qualitative hedge with the cited
+    **20–40% vs 1–3%** range + sources, keeping it a *range* on purpose (the true
+    lift varies by relationship — honest, matches the sources);
+  - FAQ "warm intro vs cold outreach": added the sourced range;
+  - editorial/staging note: rewritten to reflect the sourced range **and** to flag
+    the honesty nuance — platform-wide cold-email averages actually run ~3.4% (2026);
+    the 1–3% used here is the warm-vs-cold comparison framing those guides use,
+    which is the apt contrast for a warm-intro page.
+- Verified no stray `1%`/`qualitative` strings remain in the draft.
+
+**Judgment call (recorded, not a DECISIONS-level entry)**
+- **Did NOT touch the Cluster A listicle (#16) this run.** Research §5.5 also actions
+  a cold-email reframe there ("~1%" → "the average is collapsing", Instantly
+  5.1%→3.4%). But that edit changes the article's central hook and conflicts with
+  the brand's established ~1% figure — a positioning call, not a mechanical stat
+  swap — so I logged it as an explicit pre-publish follow-up on Backlog #16 rather
+  than half-execute it autonomously. Item #17's edit was the flagged, low-risk,
+  internally-consistent top action; keeping the commit atomic to it.
+
+**Shipping** — docs-only (one content draft + BACKLOG/report/metrics updates). No
+app/test source, no §3b surface → **branch `content/warm-intro-sourced-stats` → PR**
+(matches the docs/ops cadence; keeps main board-visible). No version bump
+(unpublished draft, not shippable app code, per `.ai-instructions.md`). No gate tripped.
+
+**What's blocked** (unchanged, board-side): WP App Password rotation + publish
+pipeline (#14/#14b) — the wall for all three content drafts; scheduler host (#6);
+approved posting accounts (#15); ops-script allowlist for headless runs. Real
+keyword-tool volumes (Ahrefs/Semrush/GSC) still needed to confirm estimates.
+
+**Alerts:** none this run.

--- a/ops/logs/site-check-20260710T072238Z.json
+++ b/ops/logs/site-check-20260710T072238Z.json
@@ -1,0 +1,22 @@
+﻿{
+    "ts":  "20260710T072238Z",
+    "base":  "https://app.donatalk.com",
+    "allOk":  true,
+    "checks":  [
+                   {
+                       "path":  "/",
+                       "status":  200,
+                       "ok":  true
+                   },
+                   {
+                       "path":  "/listeners",
+                       "status":  200,
+                       "ok":  true
+                   },
+                   {
+                       "path":  "/login",
+                       "status":  200,
+                       "ok":  true
+                   }
+               ]
+}

--- a/ops/logs/site-check-20260710T100005Z.json
+++ b/ops/logs/site-check-20260710T100005Z.json
@@ -1,0 +1,22 @@
+﻿{
+    "ts":  "20260710T100005Z",
+    "base":  "https://app.donatalk.com",
+    "allOk":  true,
+    "checks":  [
+                   {
+                       "path":  "/",
+                       "status":  200,
+                       "ok":  true
+                   },
+                   {
+                       "path":  "/listeners",
+                       "status":  200,
+                       "ok":  true
+                   },
+                   {
+                       "path":  "/login",
+                       "status":  200,
+                       "ok":  true
+                   }
+               ]
+}

--- a/ops/logs/site-check-20260710T102039Z.json
+++ b/ops/logs/site-check-20260710T102039Z.json
@@ -1,0 +1,22 @@
+﻿{
+    "ts":  "20260710T102039Z",
+    "base":  "https://app.donatalk.com",
+    "allOk":  true,
+    "checks":  [
+                   {
+                       "path":  "/",
+                       "status":  200,
+                       "ok":  true
+                   },
+                   {
+                       "path":  "/listeners",
+                       "status":  200,
+                       "ok":  true
+                   },
+                   {
+                       "path":  "/login",
+                       "status":  200,
+                       "ok":  true
+                   }
+               ]
+}


### PR DESCRIPTION
## What

Applies run-11's sourced benchmark to the staged Cluster B pillar
`docs/company/content/how-to-get-warm-introductions.md`, replacing the
deliberately-qualitative warm-vs-cold hedge with the now-cited
**warm-intro 20–40% vs cold 1–3%** range (askscout.ai, launchleads.com) in five
places: intro, warm-vs-cold table, "note on numbers" block, FAQ, editorial note.

Kept as a **range** on purpose — the true lift varies by relationship, which is
honest and matches the sources. Editorial note flags the honesty nuance:
platform-wide cold-email averages actually run ~3.4% (2026); the 1–3% used here is
the warm-vs-cold comparison framing those guides use, apt for a warm-intro page.

## Why

Backlog #17 flagged this pre-publish edit as ready. Draft is now stat-final;
publish remains blocked on WP App Password rotation + pipeline (#14/#14b).

## Not in this PR

Cluster A listicle (#16) reframe (research §5.5) — logged as a scoped pre-publish
follow-up, not executed, since it touches the article's central hook and the
brand's established ~1% figure (a positioning call, not a mechanical swap).

## Surface / gates

Docs-only, **no §3b money/auth/email/secret surface**, no app or test source, no
version bump (unpublished draft). Also carries this run's metric rows, probe logs,
and BACKLOG/report updates. Probe green this run (`site-check-20260710T102039Z`,
all 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)