### PR TITLE
content(seo): draft Cluster C WP explainer 'what is donation-based outreach' (#18)

### DIFF
--- a/docs/company/BACKLOG.md
+++ b/docs/company/BACKLOG.md
@@ -2,7 +2,7 @@
 
 > Ordered work queue. Each scheduled run advances the top **unblocked** item.
 > Status: ⬜ todo · 🟡 in progress · ✅ done · 🔴 BLOCKED
-> Last updated: 2026-07-10 (run 14 — #16 cold-email hook reframed to sourced "average is collapsing")
+> Last updated: 2026-07-10 (run 15 — #18 Cluster C WP explainer drafted; all 3 cluster drafts publish-ready)
 
 ## Now (Obj 1 — the machine)
 | # | Item | KR | Status |
@@ -36,7 +36,7 @@
 |---|------|----|--------|
 | 16 | Cluster A listicle — "cold email alternatives" (`donatalk.com/blog/`) | 2-1→2-3 | 🟡 drafted `docs/company/content/cold-email-alternatives.md` (publish-ready, brand-voice, Sec 6-truthful). **Pre-publish edit DONE (run 14):** reframed the flat "~1%" hook to the sourced **"average is collapsing"** framing — platform-avg **~5.1% (2024) → ~3.4% (2026, Instantly)**, with **1–3%** kept as the warm-comparison range; added the honest "cold email isn't dead (elite 10–18%, 61% still prefer it)" nuance per `research/2026-07-10-keywords.md` §1/§5.5. Meta desc, opening hook, closing line, editorial note all updated (4 occurrences). Channels-not-tools angle confirmed already in place. Draft now stat-final (matches #17). **Publish still blocked:** WP App Password rotation + pipeline #14b (built, awaiting creds). |
 | 17 | Cluster B pillar + template — "how to get warm introductions" | 2-1→2-3 | 🟡 drafted `docs/company/content/how-to-get-warm-introductions.md` (run 8): definitional pillar + how-to (double opt-in ask) + 2 original copy-paste templates (ask-connector + forwardable blurb) + exec sub-cluster + FAQ; bridges to Cluster C via donation-based outreach for the "no mutual connection" case. Brand-voice, Sec-6 truthful. **Pre-publish edit DONE (run 12):** qualitative hedge swapped for the sourced **warm-intro 20–40% vs cold 1–3%** range (intro, vs-table, note-block, FAQ, editorial note) — kept as a range per `research/2026-07-10-keywords.md`; editorial note flags platform-avg cold (~3.4%) vs the 1–3% warm-comparison framing. Draft now stat-final. **Publish still blocked:** WP App Password rotation + pipeline (items 14/14b). |
-| 18 | Cluster C explainer + app `/vs` page — "donation-based outreach" | 2-1→2-3 | 🟡 **`/vs` shipped+merged (v0.13.0, PR #29, run 7)** + **impact calculator shipped (v0.14.0, run 9):** `app/calculator/page.tsx` (server: metadata + WebApplication/Breadcrumb/FAQPage JSON-LD) + `OutreachCalculator.tsx` (client: target meetings × donation × editable ~1% reply rate → monthly donation impact, 4.9% fee cost, all-in cost/meeting, cold-message volume). All outputs = arithmetic on visitor input (no invented metrics, Sec 6); in sitemap; cross-links to `/vs` + `/listeners`. tsc clean, 598 unit tests green, non-§3b. Remaining: thin WP `what-is-donation-based-outreach` explainer (WP-publish-blocked, item 14b) |
+| 18 | Cluster C explainer + app `/vs` page — "donation-based outreach" | 2-1→2-3 | 🟡 **`/vs` shipped+merged (v0.13.0, PR #29, run 7)** + **impact calculator shipped (v0.14.0, run 9):** `app/calculator/page.tsx` (server: metadata + WebApplication/Breadcrumb/FAQPage JSON-LD) + `OutreachCalculator.tsx` (client: target meetings × donation × editable ~1% reply rate → monthly donation impact, 4.9% fee cost, all-in cost/meeting, cold-message volume). All outputs = arithmetic on visitor input (no invented metrics, Sec 6); in sitemap; cross-links to `/vs` + `/listeners`. tsc clean, 299 unit tests green, non-§3b. **WP explainer DRAFTED (run 15):** `docs/company/content/what-is-donation-based-outreach.md` — definitional/featured-snippet-first explainer (definition → Warren Buffett cultural hook → how it works → reply-rate math → gift-card contrast → category context → DonaTalk differentiators → fit → FAQ), brand-voice, Sec-6 truthful. Stats match the run-14 convention (cold ~5.1%→~3.4%, 1–3% warm-vs-cold range, warm-intro 20–40%); competitors described at category level (non-defamatory), DonaTalk framed by concrete differentiators (self-serve/any-vertical/Listener-chosen cause/4.9% fee), NOT "first/only"; cross-links to `/vs` + `/calculator` + the #17 draft. **All 3 cluster drafts now publish-ready.** Publish still blocked: WP App Password rotation + pipeline #14b. |
 | 14b | WordPress publish pipeline: markdown draft → WP REST draft post (reads creds from env) | 2-2 | 🟡 **built + dry-run-verified 2026-07-10** (run 13): `ops/publish-wp.mjs` + pure converter `ops/lib/md-to-wp.mjs` (frontmatter + Markdown→HTML: headings/bold/italic/links/lists/GFM tables/blockquotes/hr). Creds env-only (never hardcoded, §6); **draft by default**, live needs explicit `--publish`; `--dry-run`/missing-creds = no network. 18 unit tests (suite now 25 files/317). Dry-run-verified against both drafts (tables/quotes/lists render, no leftover markdown). **Live publish still gated on WP App Password rotation** — pipeline is ready the moment the board rotates. |
 
 ## Follow-ups (unblocked, this cycle)
@@ -54,9 +54,9 @@
 - Always-on scheduler host (item 6).
 - Approved posting accounts (item 15).
 - **Rotate WordPress App Password (transited chat).** ← now the *single* unlock for the
-  entire Obj-2 content chain: 3 drafts are publish-ready and the publish pipeline (#14b)
-  is built + dry-run-verified. The moment a rotated password lands in env, `ops/publish-wp.mjs`
-  ships them as WP drafts. Nothing else blocks first-content-live.
+  entire Obj-2 content chain: **all 3 cluster drafts (A/B/C) are publish-ready** and the publish
+  pipeline (#14b) is built + dry-run-verified. The moment a rotated password lands in env,
+  `ops/publish-wp.mjs` ships them as WP drafts. Nothing else blocks first-content-live.
 
 ## Later
 - ~~cost-of-cold-outreach calculator~~ ✅ shipped as `/calculator` (v0.14.0, run 9). More `/vs` competitor/comparison pages.

--- a/docs/company/content/README.md
+++ b/docs/company/content/README.md
@@ -43,3 +43,4 @@ author: DonaTalk (CEO agent)
 |------|---------|---------|--------|
 | `cold-email-alternatives.md` | A | WordPress | draft |
 | `how-to-get-warm-introductions.md` | B | WordPress | draft |
+| `what-is-donation-based-outreach.md` | C | WordPress | draft |

--- a/docs/company/content/what-is-donation-based-outreach.md
+++ b/docs/company/content/what-is-donation-based-outreach.md
@@ -1,0 +1,181 @@
+---
+title: "What Is Donation-Based Outreach? A 2026 Explainer"
+slug: what-is-donation-based-outreach
+surface: wordpress
+target_url: https://donatalk.com/blog/what-is-donation-based-outreach
+cluster: C
+primary_keyword: donation-based outreach
+secondary_keywords:
+  - what is donation-based outreach
+  - donate to get a meeting
+  - charitable outreach B2B
+  - buy a meeting for charity
+  - pay for meeting with donation
+meta_description: "Donation-based outreach books a warm B2B meeting by donating to a cause your prospect picks. How it works, why it lifts reply rates, and when to use it."
+status: draft
+author: DonaTalk (CEO agent)
+---
+
+# What Is Donation-Based Outreach?
+
+**Donation-based outreach is a way to earn a B2B meeting by committing a donation
+to a cause the person you want to meet actually cares about — instead of paying
+them, gifting them, or cold-emailing them into submission.** The prospect picks
+the charity. You fund it. They give you the conversation. A cause they support is
+better off for it.
+
+It's a small idea with a familiar pedigree. Every year, someone pays millions in
+a charity auction to have lunch with Warren Buffett; the money goes to a food
+bank, and the winner gets a conversation they'd never otherwise land. Donation-
+based outreach is that same trade — access in exchange for a charitable gift —
+made self-serve, right-sized, and available for any B2B meeting, not just a
+billionaire's calendar.
+
+## How it works
+
+Strip away the branding and there are three moving parts:
+
+1. **A seller who wants a meeting** (on [DonaTalk](https://donatalk.com) we call
+   them the **Pitcher**).
+2. **A person worth meeting** who's willing to hear a pitch on the right terms
+   (the **Listener**).
+3. **A cause the Listener chooses**, funded by the Pitcher's donation, that turns
+   "why should I give you my time?" into "sure — and my charity wins too."
+
+The Pitcher commits a donation to the Listener's chosen non-profit in exchange for
+a real, agreed-upon conversation. No gift card, no honorarium, no money changing
+hands into anyone's pocket. The value goes to charity, and the meeting is warm by
+construction: the Listener said yes on purpose.
+
+**What if every sales call you made also helped a non-profit?** That's the whole
+premise. The incentive isn't bolted onto the outreach — the incentive *is* the
+outreach.
+
+## Why it works (the reply-rate math)
+
+Cold email's average is collapsing. Platform-wide, the average B2B cold-email
+reply rate has fallen from about 5.1% in 2024 to roughly **3.4% in 2026**
+(Instantly benchmark), and warm-outreach guides routinely peg cold at just
+**1–3%**. Inbox saturation, tighter spam enforcement, and a flood of low-effort
+AI-generated outreach keep pulling the number down.
+
+Warm introductions sit at the other end of the spectrum: independent sources put
+warm-intro reply rates at roughly **20–40%**, versus that **1–3%** for cold. The
+lift is an order of magnitude, and the reason is simple — a warm intro borrows
+someone's trust, so you skip the "who are you?" phase entirely.
+
+The catch with warm intros is that they're gated by whether you *have* a mutual
+connection. Most of the time, you don't. **Donation-based outreach manufactures
+the warm reason to connect when no mutual friend exists** — you offer the prospect
+something they genuinely value (support for a cause they chose) as the reason to
+say yes. That's why it belongs in the same conversation as referrals and warm
+intros, not in the same bucket as spray-and-pray cold email.
+
+## How it's different from a gift card or a bribe
+
+The instinct to "sweeten" outreach with a gift card, a coffee voucher, or a raffle
+entry is old — and it carries an ick that most buyers feel immediately. Paying a
+prospect personally to take a meeting looks like exactly what it is.
+
+Donation-based outreach sidesteps that entirely because **the money never reaches
+the prospect.** It goes to a non-profit *they* selected. There's no personal
+enrichment, no "is this even allowed?" gray area — just a charitable gift attached
+to a request for a conversation. Many organizations that would never let an
+employee accept a $50 gift card have no problem with a donation to a cause. (Some
+executive-facing versions of this model even let the recipient waive the donation
+for compliance reasons — the charitable framing is what keeps it clean.)
+
+## Is this a new idea?
+
+The trade itself — access in return for a charitable gift — is old, but doing it
+deliberately for B2B meetings is young. A handful of networks have started running
+donation-for-access models, mostly aimed at finance and executive circles: think
+invite-only communities where senior people accept filtered requests in exchange
+for a donation to their cause. They prove the model works. They also tend to be
+closed networks built around scarce, high-status calendars.
+
+DonaTalk takes the same core idea in a different direction:
+
+- **Self-serve, not invite-only.** You don't have to be admitted to a network —
+  you sign up and send a request.
+- **The Listener picks the cause.** The person being pitched controls where the
+  donation goes, every time.
+- **Built for everyday B2B sellers**, not only asset managers and C-suite gate-
+  keepers — the reps who actually feel the cold-email squeeze.
+- **Transparent economics.** DonaTalk charges a flat **4.9% fee** on the committed
+  donation; the rest goes to the cause.
+
+We're not claiming to have invented the concept — the charity-lunch idea predates
+all of us. What DonaTalk offers is the self-serve, seller-side, any-vertical
+version of it.
+
+## Is donation-based outreach right for you?
+
+It's a good fit if you:
+
+- Sell into people who are hard to reach cold but not impossible to interest.
+- Would rather book fewer, warmer meetings than blast hundreds of emails for a
+  handful of replies.
+- Are comfortable putting a small donation behind a request instead of a discount
+  or a gift.
+
+It's probably *not* your move if you need thousands of touches a week and measure
+success purely on volume — this trades quantity for meetings that start on good
+terms.
+
+Want to see how it stacks up against cold email and paid gifting side by side?
+Read the [comparison breakdown](https://donatalk.com/vs), or estimate the donation
+impact of your own outreach with the
+[impact calculator](https://donatalk.com/calculator).
+
+## Frequently asked questions
+
+**Is donation-based outreach the same as paying for a meeting?**
+No. You're not paying the person — you're donating to a non-profit *they* chose.
+The recipient is never personally compensated; a cause they care about is.
+
+**Is it tax-deductible?**
+Whether a specific donation is deductible depends on the receiving non-profit's
+status and your local tax rules — check with the charity or a tax professional.
+DonaTalk doesn't provide tax advice.
+
+**How is it different from a warm introduction?**
+A warm introduction relies on a mutual connection vouching for you. Donation-based
+outreach creates a warm reason to connect when you *don't* have that mutual
+connection — by funding a cause the prospect values. (For the fundamentals of
+classic intros, see our guide on
+[how to get warm introductions](https://donatalk.com/blog/how-to-get-warm-introductions).)
+
+**Does the prospect have to accept?**
+No. It's an offer, not a purchase. The Listener chooses whether to accept the
+conversation, and only then is the donation committed.
+
+**What does DonaTalk charge?**
+A flat 4.9% fee on the committed donation. The remainder goes to the Listener's
+chosen non-profit.
+
+---
+
+Cold email still works for the teams that run it as a system, but the average is
+eroding, and "please give me your time" is a weaker ask every quarter. Donation-
+based outreach answers the one question cold email never does: *what's in it for
+the person on the other end?*
+
+**What if every sales call you made also helped a non-profit?**
+[See how DonaTalk works →](https://donatalk.com)
+
+---
+
+*Editorial note (staging): first-party claims (mechanism, Pitcher/Listener model,
+"the Listener picks the cause," self-serve sign-up, flat 4.9% fee) are accurate to
+the DonaTalk product. Reply-rate figures are sourced from the 2026 benchmark pass
+(`docs/company/research/2026-07-10-keywords.md`): cold platform-average ~5.1%
+(2024) → ~3.4% (2026, Instantly), with 1–3% the range warm-outreach guides cite
+for cold, and warm-intro reply rates of 20–40% — all kept as ranges per source.
+The Warren Buffett charity-lunch reference is used as a widely-known cultural
+analogy, not a DonaTalk claim. Competing donation-for-access models are described
+at the category level (no named product specifics) to stay truthful and non-
+defamatory per Charter Sec 6; DonaTalk is framed by its concrete differentiators
+(self-serve, any-vertical, Listener-chosen cause, 4.9% fee), NOT as "first" or
+"only." Do not publish until the WordPress App Password is rotated (Backlog
+blocker).*

--- a/docs/company/metrics/awareness-log.csv
+++ b/docs/company/metrics/awareness-log.csv
@@ -13,3 +13,4 @@ date_utc,A1,A2,A3,A4,A5,A6,A7,note
 2026-07-10,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger
 2026-07-10,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger
 2026-07-10,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger
+2026-07-10,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger

--- a/docs/company/metrics/funnel-log.csv
+++ b/docs/company/metrics/funnel-log.csv
@@ -13,3 +13,4 @@ date_utc,F1,F2,F3,F4,R1,note
 2026-07-10,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account
 2026-07-10,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account
 2026-07-10,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account
+2026-07-10,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account

--- a/docs/company/metrics/ops-health-log.csv
+++ b/docs/company/metrics/ops-health-log.csv
@@ -18,3 +18,4 @@ ts_utc,run_type,H1,H2,H3,H4,note
 20260710T114438Z,probe,success,none,pass,not-run,critical-path probe
 20260710T132040Z,probe,success,none,pass,not-run,critical-path probe
 20260710T132238Z,probe,success,none,pass,not-run,critical-path probe
+20260710T162039Z,probe,success,none,pass,not-run,critical-path probe

--- a/docs/company/reports/2026-07-10-daily.md
+++ b/docs/company/reports/2026-07-10-daily.md
@@ -429,3 +429,78 @@ it); scheduler host (#6); approved posting accounts (#15); ops-script allowlist
 for headless runs. Real keyword-tool volumes (Ahrefs/Semrush/GSC) still needed.
 
 **Alerts:** none this run.
+
+---
+
+## Run 15 — 20260710T1620Z (daily-ops, every-3h)
+
+**Headline:** Drafted the missing **Cluster C WordPress explainer** — "What Is
+Donation-Based Outreach?" (`docs/company/content/what-is-donation-based-outreach.md`).
+This was the one un-drafted piece of item 18 and the last content asset the Obj-2
+chain was missing. **All three cluster drafts (A/B/C) are now publish-ready** — the
+moment the WP App Password rotates and the #14b pipeline fires, the full batch
+ships with zero further content work.
+
+**Health snapshot**
+- Synthetic probe: **green** — newest artifact `site-check-20260710T162039Z.json`,
+  `allOk:true`, `/`, `/listeners`, `/login` all 200.
+- Metrics coverage (KR1-2, runner-collected this run): ops-health
+  `20260710T162039Z,probe,success,none,pass` appended; awareness `A1-A6 n/a`
+  (GSC/GA4 creds pending) / `A7=0` (empty ledger); funnel `F1-F4/R1 n/a`
+  (Firebase Admin pending). No fabricated numbers.
+
+**What advanced (Obj 2 — KR2-1 → 2-3)**
+- **Backlog #18 WP explainer → 🟡 drafted.** Wrote the definitional Cluster C
+  piece, structured for a featured-snippet + vocabulary-ownership play (research
+  §3/§4 flagged Cluster C's *search* surface as near-empty — highest strategic
+  value, lowest competition):
+  - **Definition-first** opening (2-sentence answer for snippet capture), then the
+    **Warren Buffett charity-lunch** cultural hook (research §3, §5.4) as the
+    familiar analogy → how it works (Pitcher / Listener / Listener-chosen cause /
+    donation) → the reply-rate math → gift-card/bribe contrast → honest category
+    context → DonaTalk differentiators → fit → a 5-question FAQ → CTA.
+  - **Cross-links** to the app's `/vs` and `/calculator` pages and to the #17
+    warm-intro pillar — internal-linking the Cluster B→C funnel the strategy
+    depends on.
+- **Content Rules (§6) honored:**
+  - Stats follow the run-14 DECISIONS convention exactly — cold platform-avg
+    ~5.1% (2024) → ~3.4% (2026, Instantly); **1–3%** kept as the *warm-vs-cold
+    comparison range*; warm-intro **20–40%** — all as ranges, sourced from
+    `research/2026-07-10-keywords.md`.
+  - **Competitors described at the category level only** (no named product
+    specifics) — non-defamatory per §6; the TGN £300→COO anecdote from research
+    §3 was deliberately **not** used (it's theirs, not a DonaTalk result).
+  - DonaTalk framed by concrete, first-party-true differentiators (self-serve /
+    any-vertical / Listener picks the cause / flat 4.9% fee), **NOT** "first" or
+    "only" — the honest, defensible framing research §3 prescribed.
+  - First-party claims (Pitcher/Listener model, 4.9% fee, declined-meeting = no
+    charge) mirror the live product; the tax-deductibility FAQ explicitly declines
+    to give tax advice. Registered in the content-staging README index.
+
+**Why item 18's explainer, not 5/6/15/16/17:** Obj-1 machine items remain at their
+autonomous ceiling (#5 live-fire deferred-by-design; #6 scheduler host + #15
+posting accounts board-side). Drafts #16 (A) and #17 (B) are already stat-final
+(runs 12/14); #14b pipeline is built + dry-run-verified (run 13). The Cluster C WP
+explainer was the **only un-drafted content asset** — item 18's app work (`/vs`,
+`/calculator`) shipped, but its "thin WP explainer" component had never been
+written. Drafting it needs no credential (Charter §3a + §6), is fully in autonomy,
+and closes the last content-readiness gap: the publish batch is now A+B+C complete.
+
+**Not a new DECISIONS entry:** drafting an unpublished SEO asset is already-settled
+CEO-autonomous work under the run-12/13/14 convention (DECISIONS 2026-07-10) — this
+run *applies* that precedent, it doesn't set new policy (Charter §11: only
+board-relevant decisions go in DECISIONS).
+
+**Shipping** — docs-only (one content draft + staging README + BACKLOG/report;
+metrics + probe logs are the run's KR1-2 trace). No app/test source, no §3b surface
+→ **branch `content/cluster-c-donation-outreach-explainer-18` → PR** (matches the
+docs/ops cadence; keeps main board-visible). No version bump (unpublished draft,
+not shippable app code, per `.ai-instructions.md`). No gate tripped.
+
+**What's blocked** (board-side, unchanged): **WP App Password rotation — the sole
+unlock for the whole Obj-2 content chain** (now all 3 drafts + the built pipeline
+wait only on it); scheduler host (#6); approved posting accounts (#15); ops-script
+allowlist for headless runs. Real keyword-tool volumes (Ahrefs/Semrush/GSC) still
+needed to confirm estimates.
+
+**Alerts:** none this run.

--- a/ops/logs/site-check-20260710T132238Z.json
+++ b/ops/logs/site-check-20260710T132238Z.json
@@ -1,0 +1,22 @@
+﻿{
+    "ts":  "20260710T132238Z",
+    "base":  "https://app.donatalk.com",
+    "allOk":  true,
+    "checks":  [
+                   {
+                       "path":  "/",
+                       "status":  200,
+                       "ok":  true
+                   },
+                   {
+                       "path":  "/listeners",
+                       "status":  200,
+                       "ok":  true
+                   },
+                   {
+                       "path":  "/login",
+                       "status":  200,
+                       "ok":  true
+                   }
+               ]
+}

--- a/ops/logs/site-check-20260710T162039Z.json
+++ b/ops/logs/site-check-20260710T162039Z.json
@@ -1,0 +1,22 @@
+﻿{
+    "ts":  "20260710T162039Z",
+    "base":  "https://app.donatalk.com",
+    "allOk":  true,
+    "checks":  [
+                   {
+                       "path":  "/",
+                       "status":  200,
+                       "ok":  true
+                   },
+                   {
+                       "path":  "/listeners",
+                       "status":  200,
+                       "ok":  true
+                   },
+                   {
+                       "path":  "/login",
+                       "status":  200,
+                       "ok":  true
+                   }
+               ]
+}


### PR DESCRIPTION
## What
Drafts the missing **Cluster C WordPress explainer** — `docs/company/content/what-is-donation-based-outreach.md` — completing item 18's WP component. With this, **all three cluster drafts (A/B/C) are publish-ready**; the WP App Password rotation is now the sole board action before first-content-live.

## Why this item (run 15, daily-ops)
Obj-1 machine items are at their autonomous ceiling (#5 live-fire deferred-by-design; #6 scheduler host + #15 posting accounts board-side). Drafts #16/#17 are stat-final; #14b pipeline is built + dry-run-verified. The Cluster C WP explainer was the **only un-drafted content asset** — item 18's app work (`/vs`, `/calculator`) shipped, but its "thin WP explainer" had never been written. Drafting needs no credential (Charter §3a + §6).

## Content (Charter §6 honored)
- **Definition-first** (featured-snippet capture) → **Warren Buffett charity-lunch** cultural hook → how it works → reply-rate math → gift-card/bribe contrast → honest category context → DonaTalk differentiators → fit → FAQ → CTA.
- Stats follow the run-14 DECISIONS convention: cold ~5.1% (2024) → ~3.4% (2026, Instantly); **1–3%** as the warm-vs-cold comparison range; warm-intro **20–40%** — all as ranges, sourced from `research/2026-07-10-keywords.md`.
- **Competitors at the category level only** (non-defamatory); the third-party £300→COO anecdote deliberately **not** used (theirs, not ours). DonaTalk framed by concrete first-party differentiators (self-serve / any-vertical / Listener-chosen cause / 4.9% fee), **not** "first/only".
- Cross-links to `/vs`, `/calculator`, and the #17 warm-intro pillar.

## Gates
- Docs-only (content draft + staging README index + BACKLOG/report; metrics + probe logs = KR1-2 trace). No app/test source, **no §3b surface** → no version bump. No deploy gate tripped.
- Health probe green this run (`site-check-20260710T162039Z.json`, all 3 paths 200).

**Do not publish** until the WordPress App Password is rotated (Backlog blocker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)