### PR TITLE
seo(v0.14.2): internal-link /vs + /calculator (site-wide footer + reciprocal cross-link)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to DonaTalk are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [SemVer](https://semver.org/).
 
+## [0.14.2] - 2026-07-10
+
+### Changed (SEO — internal linking of Cluster C pages)
+- `components/Footer.tsx` — added site-wide footer links to `/vs` ("Donation-based outreach vs. cold email") and `/calculator` ("Outreach impact calculator"). Both pages were in the sitemap but had **no inbound internal links** from the app's navigation, so they got minimal crawl equity and zero human discovery from the main funnel. The footer renders on every page (via `app/layout.tsx`), giving both SEO pages consistent internal links and a visible entry point.
+- `app/vs/page.tsx` — added a reciprocal CTA link `/vs` → `/calculator` ("Estimate your donation impact →"). `/calculator` already linked to `/vs`; this closes the loop so the two Cluster C pages cross-link both ways. Non-behavioral; links + copy only (Charter Sec 6, no §3b surface).
+
 ## [0.14.1] - 2026-07-10
 
 ### Changed (SEO content — Cluster C truthfulness)

--- a/app/vs/page.tsx
+++ b/app/vs/page.tsx
@@ -415,6 +415,7 @@ export default function VsPage() {
         <CtaRow>
           <SecondaryHint>Ready to try warm, charitable outreach?</SecondaryHint>
           <PrimaryCTA href="/listeners">Browse people to pitch →</PrimaryCTA>
+          <SecondaryCTA href="/calculator">Estimate your donation impact →</SecondaryCTA>
           <SecondaryCTA href="/pitcher/signup">Start pitching — join as a pitcher</SecondaryCTA>
         </CtaRow>
       </Container>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -37,6 +37,8 @@ export default function Footer() {
     <FooterContainer>
       <div>© {new Date().getFullYear()} DonaTalk. All rights reserved.</div>
       <FooterLinks>
+        <FooterLink href="/vs">Donation-based outreach vs. cold email</FooterLink>
+        <FooterLink href="/calculator">Outreach impact calculator</FooterLink>
         <FooterLink href="https://donatalk.com/category/blog/">Blog</FooterLink>
         <FooterLink href="https://donatalk.com/terms-of-service/">Terms of Service</FooterLink>
         <FooterLink href="https://donatalk.com/privacy-policy/">Privacy Policy</FooterLink>

--- a/docs/company/BACKLOG.md
+++ b/docs/company/BACKLOG.md
@@ -2,7 +2,7 @@
 
 > Ordered work queue. Each scheduled run advances the top **unblocked** item.
 > Status: ⬜ todo · 🟡 in progress · ✅ done · 🔴 BLOCKED
-> Last updated: 2026-07-10 (run 16 — live `/vs` page stat aligned to sourced collapsing-average convention, v0.14.1 shipped)
+> Last updated: 2026-07-10 (run 17 — internal-linking fix: `/vs` + `/calculator` were sitemap-listed but had no inbound app links; footer now links both site-wide + `/vs`↔`/calculator` reciprocal, v0.14.2 shipped)
 
 ## Now (Obj 1 — the machine)
 | # | Item | KR | Status |
@@ -60,5 +60,6 @@
 
 ## Later
 - ~~cost-of-cold-outreach calculator~~ ✅ shipped as `/calculator` (v0.14.0, run 9). More `/vs` competitor/comparison pages.
+- ~~Internal links to `/vs` + `/calculator`~~ ✅ done run 17 (v0.14.2): both pages were in `sitemap.ts` but had **zero inbound internal links** from app nav (semi-orphaned → weak crawl equity + no human discovery). Fixed: site-wide `Footer.tsx` now links both (keyword-rich anchors), and `/vs`↔`/calculator` cross-link reciprocally. Non-§3b, deploy-gated (tsc + 317 tests green).
 - Cause-story content series (Listeners' non-profits) for donatalk.com blog.
 - `.env.example`; API rate limiting; cookie consent (from product backlog).

--- a/docs/company/metrics/awareness-log.csv
+++ b/docs/company/metrics/awareness-log.csv
@@ -15,3 +15,4 @@ date_utc,A1,A2,A3,A4,A5,A6,A7,note
 2026-07-10,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger
 2026-07-10,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger
 2026-07-10,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger
+2026-07-10,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger

--- a/docs/company/metrics/funnel-log.csv
+++ b/docs/company/metrics/funnel-log.csv
@@ -15,3 +15,4 @@ date_utc,F1,F2,F3,F4,R1,note
 2026-07-10,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account
 2026-07-10,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account
 2026-07-10,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account
+2026-07-10,n/a,n/a,n/a,n/a,n/a,F1-F4/R1 pending Firebase Admin service account

--- a/docs/company/metrics/ops-health-log.csv
+++ b/docs/company/metrics/ops-health-log.csv
@@ -21,3 +21,4 @@ ts_utc,run_type,H1,H2,H3,H4,note
 20260710T162039Z,probe,success,none,pass,not-run,critical-path probe
 20260710T192039Z,probe,success,none,pass,not-run,critical-path probe
 20260710T192238Z,probe,success,none,pass,not-run,critical-path probe
+20260710T222039Z,probe,success,none,pass,not-run,critical-path probe

--- a/docs/company/reports/2026-07-10-daily.md
+++ b/docs/company/reports/2026-07-10-daily.md
@@ -572,3 +572,69 @@ scheduler host (#6); approved posting accounts (#15); ops-script allowlist for
 headless runs. Real keyword-tool volumes (Ahrefs/Semrush/GSC) still needed.
 
 **Alerts:** none this run.
+
+---
+
+## Run 17 — 20260710T2220Z (daily-ops, every-3h)
+
+**Headline:** Fixed an internal-linking gap on the shipped Cluster C pages.
+`/vs` and `/calculator` were both in `sitemap.ts` but had **zero inbound internal
+links** from the app's own navigation — semi-orphaned pages get thin crawl equity
+and are invisible to real visitors. Added them to the site-wide footer and closed
+the `/vs`↔`/calculator` reciprocal link. Shipped v0.14.2 — the second production
+change this cycle (WP content chain remains board-blocked).
+
+**Health snapshot**
+- Synthetic probe: **green** — newest artifact `site-check-20260710T222039Z.json`,
+  `allOk:true`, `/`, `/listeners`, `/login` all 200.
+- Metrics coverage (KR1-2, runner-collected this run): ops-health
+  `20260710T222039Z,probe,success,none,pass` appended; awareness `A1-A6 n/a`
+  (GSC/GA4 creds pending) / `A7=0` (empty ledger); funnel `F1-F4/R1 n/a`
+  (Firebase Admin pending). No fabricated numbers.
+
+**What advanced (Obj 2 — KR2-1 → 2-3, internal linking / discoverability)**
+- **`components/Footer.tsx` (site-wide via `app/layout.tsx`):** added two internal
+  links — `/vs` (anchor "Donation-based outreach vs. cold email") and `/calculator`
+  (anchor "Outreach impact calculator"). Keyword-rich anchor text; renders on every
+  page → both SEO pages now have consistent site-wide inbound internal links and a
+  visible human entry point. Previously the footer only linked *out* to the WP blog
+  / terms / privacy / contact; the app's own ranking pages were unlinked.
+- **`app/vs/page.tsx`:** added a reciprocal CTA link `/vs` → `/calculator`
+  ("Estimate your donation impact →"). `/calculator` already linked to `/vs`; this
+  closes the loop so the two Cluster C pages cross-link both ways (topical cluster
+  signal + on-page funnel).
+- **Why it matters:** the strategy's Cluster C play depends on these app pages
+  ranking and converting. A sitemap entry tells Google a URL *exists*; internal
+  links tell it (and users) the page *matters* and pass equity from the rest of the
+  site. This was flagged as a next-step in runs 9/10 ("iterate app-side SEO —
+  internal linking") and is now done.
+
+**Deploy gates (Charter §4):** `npx tsc --noEmit` clean; `npm run test` = **25
+files / 317 tests pass**; touches **no §3b surface** (footer/nav links + one CTA —
+no money/auth/email/secret); version bumped 0.14.1 → **0.14.2** (PATCH — internal
+links, no behavior change) + CHANGELOG; doc version headers refreshed. Non-MINOR →
+no git tag per `.ai-instructions.md`.
+
+**Why this, not 5/6/15/16/17/18:** Obj-1 machine items remain at their autonomous
+ceiling (#5 live-fire deferred-by-design; #6 scheduler host + #15 posting accounts
+board-side). #16/#17/#18-WP-explainer + #14b are all WP-publish-blocked on the
+pending App Password rotation — no autonomous advance there. The genuinely
+unblocked, in-autonomy, *shippable* Obj-2 work was the app-side internal-linking
+gap (a "Later"-backlog item): both Cluster C pages were live-but-orphaned. It ships
+under §3a/§4 with no credential and strengthens the pages prior runs already built.
+
+**Not a new DECISIONS entry:** internal linking of already-shipped SEO pages is
+routine §3a content work, not a durable business-shaping decision (Charter §11).
+
+**Shipping** — app change (`components/Footer.tsx` + `app/vs/page.tsx` + version +
+CHANGELOG + doc headers + BACKLOG/report) → **branch
+`seo/footer-internal-links-vs-calculator` → PR → merge to `main`** (Vercel
+auto-deploys; matches the #22–#38 cadence). Next run's 6h probe validates the live
+deploy. No §3b gate tripped; no ALERT raised.
+
+**What's blocked** (board-side, unchanged): **WP App Password rotation — the sole
+unlock for the whole Obj-2 content chain** (3 drafts + built pipeline wait on it);
+scheduler host (#6); approved posting accounts (#15); ops-script allowlist for
+headless runs. Real keyword-tool volumes (Ahrefs/Semrush/GSC) still needed.
+
+**Alerts:** none this run.

--- a/docs/developer-reference.md
+++ b/docs/developer-reference.md
@@ -1,6 +1,6 @@
 # DonaTalk - Developer Reference
 
-> Last updated: 2026-07-09 | Version: 0.13.0
+> Last updated: 2026-07-10 | Version: 0.14.2
 
 ## Project Overview
 

--- a/docs/product-reference.md
+++ b/docs/product-reference.md
@@ -1,6 +1,6 @@
 # DonaTalk - Product Reference
 
-> Last updated: 2026-07-09 | Version: 0.13.0
+> Last updated: 2026-07-10 | Version: 0.14.2
 
 ## Product Vision
 

--- a/ops/logs/site-check-20260710T222039Z.json
+++ b/ops/logs/site-check-20260710T222039Z.json
@@ -1,0 +1,22 @@
+﻿{
+    "ts":  "20260710T222039Z",
+    "base":  "https://app.donatalk.com",
+    "allOk":  true,
+    "checks":  [
+                   {
+                       "path":  "/",
+                       "status":  200,
+                       "ok":  true
+                   },
+                   {
+                       "path":  "/listeners",
+                       "status":  200,
+                       "ok":  true
+                   },
+                   {
+                       "path":  "/login",
+                       "status":  200,
+                       "ok":  true
+                   }
+               ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pitcher-platform",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## What
Both Cluster C SEO pages — `/vs` and `/calculator` — were listed in `app/sitemap.ts` but had **zero inbound internal links** from the app's own navigation. Semi-orphaned pages get thin crawl equity and are invisible to real visitors.

- `components/Footer.tsx` (renders site-wide via `app/layout.tsx`) now links both pages with keyword-rich anchors:
  - `/vs` → "Donation-based outreach vs. cold email"
  - `/calculator` → "Outreach impact calculator"
- `app/vs/page.tsx` gets a reciprocal CTA to `/calculator` ("Estimate your donation impact →"). `/calculator` already linked to `/vs`; this closes the loop so the two pages cross-link both ways.

## Why
The strategy's Cluster C play depends on these app pages ranking and converting. A sitemap entry tells Google a URL exists; internal links tell it (and users) the page matters and pass equity from the rest of the site. Flagged as a next step in runs 9/10.

## Safety / gates
- **No Charter §3b surface** — footer/nav links + one CTA; no money/auth/email/secret code. Links + copy only, no behavior change.
- `npx tsc --noEmit` clean.
- `npm run test` — **317/317 pass** (25 files).
- Version 0.14.1 → **0.14.2** (PATCH) + CHANGELOG; doc version headers refreshed.

Daily-ops run 17. Probe green (3/3 paths 200); KR1-2 metric rows appended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)