### PR TITLE
seo(v0.15.1): fix doubled brand suffix in /listeners title tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to DonaTalk are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [SemVer](https://semver.org/).
 
+## [0.15.1] - 2026-07-11
+
+### Fixed (SEO — title tag)
+- `app/listeners/page.tsx` — removed the redundant `| DonaTalk` suffix from the page `title` (and the OpenGraph/Twitter titles). The root layout already applies `title.template: '%s | DonaTalk'`, so the explicit suffix produced a doubled brand in the rendered `<title>` (`… | DonaTalk | DonaTalk`). Now renders once via the template, matching `/vs` and `/calculator`. (This doubled-suffix predated v0.15.0 — the old `'Browse listeners | DonaTalk'` title had the same issue — and is corrected here.) Metadata-only, non-§3b.
+
 ## [0.15.0] - 2026-07-10
 
 ### Added (SEO — Cluster C on the primary funnel page)

--- a/app/listeners/page.tsx
+++ b/app/listeners/page.tsx
@@ -28,7 +28,7 @@ const META_DESCRIPTION =
 // and /calculator. Claims are first-party and mirror the live product ($10
 // minimum, 4.9% fee, decline = no charge) per Charter Sec 6 (truthful only).
 export const metadata: Metadata = {
-  title: 'Browse People to Pitch — Donation-Based Outreach | DonaTalk',
+  title: 'Browse People to Pitch — Donation-Based Outreach',
   description: META_DESCRIPTION,
   keywords: [
     'donation-based outreach',
@@ -42,13 +42,13 @@ export const metadata: Metadata = {
   openGraph: {
     type: 'website',
     url: `${BASE}/listeners`,
-    title: 'Browse People to Pitch — Donation-Based Outreach | DonaTalk',
+    title: 'Browse People to Pitch — Donation-Based Outreach',
     description: META_DESCRIPTION,
     images: [{ url: '/logo%20horizontal%20with%20text.png', alt: 'DonaTalk' }],
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Browse People to Pitch — Donation-Based Outreach | DonaTalk',
+    title: 'Browse People to Pitch — Donation-Based Outreach',
     description: META_DESCRIPTION,
     images: ['/logo%20horizontal%20with%20text.png'],
   },

--- a/docs/developer-reference.md
+++ b/docs/developer-reference.md
@@ -1,6 +1,6 @@
 # DonaTalk - Developer Reference
 
-> Last updated: 2026-07-10 | Version: 0.15.0
+> Last updated: 2026-07-11 | Version: 0.15.1
 
 ## Project Overview
 

--- a/docs/product-reference.md
+++ b/docs/product-reference.md
@@ -1,6 +1,6 @@
 # DonaTalk - Product Reference
 
-> Last updated: 2026-07-10 | Version: 0.15.0
+> Last updated: 2026-07-11 | Version: 0.15.1
 
 ## Product Vision
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pitcher-platform",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
Follow-up to #40. The root layout applies title.template '%s | DonaTalk'; the /listeners page title also carried an explicit '| DonaTalk', so the rendered title doubled the brand ('... | DonaTalk | DonaTalk'). Verified live on production after the #40 deploy. Dropped the suffix from the metadata title + OG/Twitter titles so the template adds it once, matching /vs and /calculator. Metadata-only, non-3b. tsc clean, 317 tests green.