### PR TITLE
seo(v0.16.0): real App Router metadata for /pitcher/signup + /listener/signup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to DonaTalk are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [SemVer](https://semver.org/).
 
+## [0.16.0] - 2026-07-11
+
+### Added (SEO — signup pages metadata)
+- `app/pitcher/signup/layout.tsx` and `app/listener/signup/layout.tsx` (new) — server-component metadata carriers for the two signup routes. Both `page.tsx` files are Client Components (`'use client'`), so they cannot export `metadata`, and the `next/head` `<Head>` blocks they used to render titles/descriptions are **no-ops in the App Router** — the pages were served with the generic root `<title>` and no canonical/OG/Twitter despite being listed in `sitemap.ts` (priority 0.6). The new layouts emit full metadata (distinct title via the root `%s | DonaTalk` template, description, Cluster-C-adjacent keywords, `alternates.canonical`, OpenGraph + Twitter cards, `robots`), matching the `/vs`, `/listeners` and `/calculator` convention. First-party, truthful claims only ($10 minimum flow, decline = no charge) per Charter Sec 6.
+
+### Removed
+- `app/pitcher/signup/page.tsx`, `app/listener/signup/page.tsx` — deleted the dead `next/head` `<Head>` blocks (and the unused `import Head`) that rendered nothing under the App Router. Metadata now lives in the sibling `layout.tsx`. No auth/data/behavior change — the signup form logic is untouched (non-§3b).
+
 ## [0.15.1] - 2026-07-11
 
 ### Fixed (SEO — title tag)

--- a/app/listener/signup/layout.tsx
+++ b/app/listener/signup/layout.tsx
@@ -1,0 +1,48 @@
+// app/listener/signup/layout.tsx
+//
+// Metadata carrier for the listener-signup route. `page.tsx` is a Client
+// Component ('use client'), so it cannot export `metadata`; a `next/head`
+// <Head> in an App Router client page is a no-op, which is why this page used
+// to inherit the generic root <title>. This server layout supplies proper
+// App Router metadata (title/description/canonical/OG/Twitter/robots) matching
+// the /vs, /listeners and /calculator convention. Metadata-only, non-behavioral
+// (no auth/data logic here) — Charter Sec 6: first-party, truthful claims only.
+
+import type { Metadata } from 'next';
+
+const BASE = process.env.NEXT_PUBLIC_BASE_URL ?? 'https://app.donatalk.com';
+
+const META_DESCRIPTION =
+  'Create your DonaTalk listener account and let people reach you by donating to a cause you choose. You hear only the pitches you accept, and your non-profit gets funded for your time — decline and nothing is charged.';
+
+export const metadata: Metadata = {
+  title: 'Sign Up as a Listener — Fund Your Cause',
+  description: META_DESCRIPTION,
+  keywords: [
+    'sign up as a listener',
+    'donation-based outreach',
+    'fund your cause',
+    'get pitched for charity',
+    'support a non-profit',
+    'warm introductions',
+  ],
+  alternates: { canonical: '/listener/signup' },
+  openGraph: {
+    type: 'website',
+    url: `${BASE}/listener/signup`,
+    title: 'Sign Up as a Listener on DonaTalk — Fund Your Cause',
+    description: META_DESCRIPTION,
+    images: [{ url: '/logo%20horizontal%20with%20text.png', alt: 'DonaTalk' }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Sign Up as a Listener on DonaTalk — Fund Your Cause',
+    description: META_DESCRIPTION,
+    images: ['/logo%20horizontal%20with%20text.png'],
+  },
+  robots: { index: true, follow: true },
+};
+
+export default function ListenerSignupLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/listener/signup/page.tsx
+++ b/app/listener/signup/page.tsx
@@ -5,7 +5,6 @@
 import slugify from 'slugify';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation'; // ✅ Updated for App Router
-import Head from 'next/head';
 import { getSafeReturnPath } from '@/lib/safeReturn';
 
 function readReturnPath(): string | null {
@@ -242,11 +241,6 @@ export default function SignupListener() {
 
   return (
     <>
-      <Head>
-        <title>Sign Up as Listener | DonaTalk</title>
-        <meta name="description" content="Sign up as a listener and discover pitches that inspire donations." />
-      </Head>
-
       <PageWrapper>
         <CardContainer>
           <Logo src="/DonaTalk_icon_88x77.png" alt="DonaTalk Logo" />

--- a/app/pitcher/signup/layout.tsx
+++ b/app/pitcher/signup/layout.tsx
@@ -1,0 +1,48 @@
+// app/pitcher/signup/layout.tsx
+//
+// Metadata carrier for the pitcher-signup route. `page.tsx` is a Client
+// Component ('use client'), so it cannot export `metadata`; a `next/head`
+// <Head> in an App Router client page is a no-op, which is why this page used
+// to inherit the generic root <title>. This server layout supplies proper
+// App Router metadata (title/description/canonical/OG/Twitter/robots) matching
+// the /vs, /listeners and /calculator convention. Metadata-only, non-behavioral
+// (no auth/data logic here) — Charter Sec 6: first-party, truthful claims only.
+
+import type { Metadata } from 'next';
+
+const BASE = process.env.NEXT_PUBLIC_BASE_URL ?? 'https://app.donatalk.com';
+
+const META_DESCRIPTION =
+  'Create your DonaTalk pitcher account and earn a warm meeting by committing a donation to a cause the person you want to reach cares about — instead of another cold email. They accept, their charity gets funded; if they decline, you pay nothing.';
+
+export const metadata: Metadata = {
+  title: 'Sign Up to Pitch — Donation-Based Outreach',
+  description: META_DESCRIPTION,
+  keywords: [
+    'sign up to pitch',
+    'donation-based outreach',
+    'cold email alternative',
+    'book a meeting for charity',
+    'pitch someone for a cause',
+    'warm introduction alternative',
+  ],
+  alternates: { canonical: '/pitcher/signup' },
+  openGraph: {
+    type: 'website',
+    url: `${BASE}/pitcher/signup`,
+    title: 'Sign Up to Pitch on DonaTalk — Donation-Based Outreach',
+    description: META_DESCRIPTION,
+    images: [{ url: '/logo%20horizontal%20with%20text.png', alt: 'DonaTalk' }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Sign Up to Pitch on DonaTalk — Donation-Based Outreach',
+    description: META_DESCRIPTION,
+    images: ['/logo%20horizontal%20with%20text.png'],
+  },
+  robots: { index: true, follow: true },
+};
+
+export default function PitcherSignupLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/pitcher/signup/page.tsx
+++ b/app/pitcher/signup/page.tsx
@@ -5,7 +5,6 @@
 import slugify from 'slugify';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation'; // ✅ Updated for App Router
-import Head from 'next/head';
 import { getSafeReturnPath } from '@/lib/safeReturn';
 
 function readReturnPath(): string | null {
@@ -254,11 +253,6 @@ export default function SignupPitcher() {
 
   return (
     <>
-      <Head>
-        <title>Sign Up as Pitcher | DonaTalk</title>
-        <meta name="description" content="Sign up as a pitcher to share your cause on DonaTalk." />
-      </Head>
-
       <PageWrapper>
         <CardContainer>
           <Logo src="/DonaTalk_icon_88x77.png" alt="DonaTalk Logo" />

--- a/docs/developer-reference.md
+++ b/docs/developer-reference.md
@@ -1,6 +1,6 @@
 # DonaTalk - Developer Reference
 
-> Last updated: 2026-07-11 | Version: 0.15.1
+> Last updated: 2026-07-11 | Version: 0.16.0
 
 ## Project Overview
 

--- a/docs/product-reference.md
+++ b/docs/product-reference.md
@@ -1,6 +1,6 @@
 # DonaTalk - Product Reference
 
-> Last updated: 2026-07-11 | Version: 0.15.1
+> Last updated: 2026-07-11 | Version: 0.16.0
 
 ## Product Vision
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pitcher-platform",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## What

Both signup pages (`app/pitcher/signup/page.tsx`, `app/listener/signup/page.tsx`) are Client Components (`'use client'`), so the `next/head` `<Head>` blocks they used for `<title>`/`<meta description>` are **no-ops under the App Router**. The pages were served with the generic root `<title>` and no canonical/OG/Twitter — despite both being listed in `sitemap.ts` (priority 0.6) and advertised to crawlers.

This adds sibling **server-component `layout.tsx`** metadata carriers for each route (the standard App Router pattern for adding metadata to a client page) and deletes the dead `<Head>` blocks + unused `import Head`.

## Metadata added (per page)
- Distinct `title` (rendered once via the root `%s | DonaTalk` template)
- `description`, Cluster-C-adjacent `keywords`
- `alternates.canonical`
- OpenGraph + Twitter (`summary_large_image`) cards
- `robots: index, follow`

Matches the established `/vs`, `/listeners`, `/calculator` convention.

## Safety
- **Metadata-only.** The signup form/auth logic (`createUserWithEmailAndPassword`, Firestore writes, `send-signup-email`) is **untouched** — non-§3b.
- First-party, truthful claims only ($10 min flow, decline = no charge) per Charter §6.
- `npx tsc --noEmit` clean; `npm run test` → **317 passed**.

Advances Backlog "Later" app-SEO follow-up (the `/pitcher/signup` + `/listener/signup` thin-metadata item) → KR 2-2a, while the WP content chain stays board-blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)