### PR TITLE
ops(wp): auto-load .env.local in publish-wp.mjs

### DIFF
--- a/ops/publish-wp.mjs
+++ b/ops/publish-wp.mjs
@@ -17,13 +17,36 @@
 //   node ops/publish-wp.mjs docs/company/content/<draft>.md --dry-run  # offline preview
 //   node ops/publish-wp.mjs docs/company/content/<draft>.md --publish  # go live (guarded)
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 import { draftToWp } from './lib/md-to-wp.mjs';
 
 function fail(msg, code = 1) {
   console.error(`ERROR: ${msg}`);
   process.exit(code);
 }
+
+// Load KEY=VALUE pairs from the repo-root .env.local into process.env (without
+// overriding anything already set). Keeps secrets in the gitignored file - the
+// runner/host env still wins if it provides them. No dotenv dependency.
+function loadEnvLocal() {
+  const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  const file = path.join(root, '.env.local');
+  if (!existsSync(file)) return;
+  for (const line of readFileSync(file, 'utf8').split(/\r?\n/)) {
+    const m = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\s*$/);
+    if (!m || line.trimStart().startsWith('#')) continue;
+    const key = m[1];
+    if (process.env[key] !== undefined) continue;
+    let val = m[2].trim();
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    process.env[key] = val;
+  }
+}
+loadEnvLocal();
 
 const args = process.argv.slice(2);
 const file = args.find((a) => !a.startsWith('--'));


### PR DESCRIPTION
Small follow-up to #35. `publish-wp.mjs` read `process.env` only, so a local `node ops/publish-wp.mjs` couldn't pick up `WORDPRESS_*` from the gitignored `.env.local`. Adds a tiny dependency-free loader that parses repo-root `.env.local` into `process.env` **without** overriding host-provided env (scheduler host still wins). Secrets stay in `.env.local`; nothing is printed.

**Verified live this session:** dry-run resolves `https://donatalk.com/wp-json/wp/v2/posts`; the three content drafts published as WP **drafts** (#156/#157/#158) for board review.

Non-§3b (ops tooling), off latest `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)