### PR TITLE
metrics: first real GSC numbers (2026-07-11)

### DIFF
--- a/docs/company/metrics/awareness-log.csv
+++ b/docs/company/metrics/awareness-log.csv
@@ -25,3 +25,4 @@ date_utc,A1,A2,A3,A4,A5,A6,A7,note
 2026-07-11,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger
 2026-07-11,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger
 2026-07-11,n/a,n/a,n/a,n/a,n/a,n/a,0,A1-A6 pending GSC/GA4 creds; A7 from ledger
+2026-07-11,n/a,n/a,10,44,6,11.9,0,"GSC 28d live-pulled (donatalk.com domain prop): impressions 44 clicks 6 CTR 13.6% pos 11.9; indexed 10 (GSC upd 6/29, pre-content); ALL 5 queries branded (dons talk/donatk/downtalk/dontalk) = 0 non-branded; 3 posts published 7/11 too fresh for GSC lag"


### PR DESCRIPTION
Live-pulled the donatalk.com Performance report (28d): impressions 44 / clicks 6 / CTR 13.6% / avg pos 11.9 / indexed 10. Replaces the n/a placeholder in the awareness log. All ranking queries still branded (0 non-branded); today's 3 posts too fresh for GSC lag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)