### PR TITLE
security(BOARD-GATED Sec3b.2): nodemailer 9.0.3 — last high Dependabot alert (v0.19.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to DonaTalk are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [SemVer](https://semver.org/).
 
+## [0.19.3] - 2026-07-12 (board-gated PR — merges only on Board approval, Charter §3b.2)
+
+### Security (email surface — nodemailer major bump)
+- `nodemailer` 8.0.11 → **9.0.3** (semver-major) — clears the last high Dependabot alert, GHSA-p6gq-j5cr-w38f (message-level `raw` option bypasses `disableFileAccess`/`disableUrlAccess` → arbitrary file read + SSRF in delivered messages). Our mailer (`lib/mailer.ts`) uses a single SMTP transport + standard `sendMail` fields and never passes `raw`/`jsonTransport`/user-supplied attachment paths, so exposure was low, but the patch only exists in 9.x. `@types/nodemailer` ^7.0.11 → ^8.0.1 (latest published). No email logic changed; tsc clean; 360/360 tests. Board-gated because nodemailer is the library behind every donor-/user-facing outbound email (§3b.2). Post-merge recommendation: one manual transactional-email smoke test (unit tests mock the transport).
+
 ## [0.19.2] - 2026-07-12
 
 ### Security (dependency updates — Dependabot triage, no code changes)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pitcher-platform",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pitcher-platform",
-      "version": "0.19.2",
+      "version": "0.19.3",
       "dependencies": {
         "@paypal/react-paypal-js": "^8.8.3",
         "@stitches/react": "^1.2.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pitcher-platform",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pitcher-platform",
-      "version": "0.19.1",
+      "version": "0.19.2",
       "dependencies": {
         "@paypal/react-paypal-js": "^8.8.3",
         "@stitches/react": "^1.2.8",
@@ -16,7 +16,7 @@
         "lucide-react": "^0.503.0",
         "next": "^15.3.9",
         "next-themes": "^0.4.6",
-        "nodemailer": "^8.0.1",
+        "nodemailer": "^9.0.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "slugify": "^1.6.6"
@@ -26,7 +26,7 @@
         "@playwright/test": "^1.60.0",
         "@rushstack/eslint-patch": "^1.9.4",
         "@types/node": "^20",
-        "@types/nodemailer": "^7.0.11",
+        "@types/nodemailer": "^8.0.1",
         "@types/react": "19.1.2",
         "eslint": "^8.56.0",
         "eslint-config-next": "^15.3.1",
@@ -2907,11 +2907,10 @@
       }
     },
     "node_modules/@types/nodemailer": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-7.0.11.tgz",
-      "integrity": "sha512-E+U4RzR2dKrx+u3N4DlsmLaDC6mMZOM/TPROxA0UAPiTgI0y4CEFBmZE+coGWTjakDriRsXG368lNk1u9Q0a2g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.1.tgz",
+      "integrity": "sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -7434,9 +7433,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "8.0.11",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.11.tgz",
-      "integrity": "sha512-nrO/pDAUKl+wXX+lx16tDLbnm0fW6sK/x8mgohaCpg+CdCEl482bD4tCuAZk2DyliruiNTIZxRCoWkDqJEnAiA==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
+      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
       "engines": {
         "node": ">=6.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pitcher-platform",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
@@ -18,7 +18,7 @@
     "lucide-react": "^0.503.0",
     "next": "^15.3.9",
     "next-themes": "^0.4.6",
-    "nodemailer": "^8.0.1",
+    "nodemailer": "^9.0.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "slugify": "^1.6.6"
@@ -28,7 +28,7 @@
     "@playwright/test": "^1.60.0",
     "@rushstack/eslint-patch": "^1.9.4",
     "@types/node": "^20",
-    "@types/nodemailer": "^7.0.11",
+    "@types/nodemailer": "^8.0.1",
     "@types/react": "19.1.2",
     "eslint": "^8.56.0",
     "eslint-config-next": "^15.3.1",


### PR DESCRIPTION
## ⛔ BOARD-GATED (Charter §3b.2 — outbound email surface). Do not self-merge.

## What

`nodemailer` 8.0.11 → **9.0.3** (semver-major) + `@types/nodemailer` ^7.0.11 → ^8.0.1 (latest published). Clears the **last high** Dependabot alert:

- **GHSA-p6gq-j5cr-w38f** — a message-level `raw` option bypasses `disableFileAccess`/`disableUrlAccess`, enabling arbitrary file read and SSRF in delivered messages. Patched only in ≥ 9.0.1.

## Why gated

nodemailer is the library behind `lib/mailer.ts` and every `send-*-email` route — a major-version behavior change on the donor-facing email surface escalates per §3b.2 even though no email logic is edited here.

## Risk assessment (CEO)

**Low in practice.** Our usage is one SMTP transport (`host/port/secure/auth`) + `sendMail` with standard fields; grep confirms no use of `raw`, `jsonTransport`, or user-supplied attachment paths anywhere. Gates pass on this branch: `tsc --noEmit` clean, 360/360 tests (27 files).

## After merge

- Any run can ship it (git integration deploys `main`; probe follows).
- Recommended: one manual transactional-email smoke test (e.g. a meeting notification) — unit tests mock the transport, so live SMTP behavior on 9.x is otherwise unexercised.

## Related

- v0.19.2 (PR #58, merged) already cleared 15/17 alerts via in-range bumps.
- Remaining after this PR: 1 moderate (`uuid`) — needs `firebase-admin` 14 (major on the **auth** surface, §3b.3); recommend bundling with the next planned firebase-admin upgrade. See `ops/logs/ALERT-security-nodemailer-20260712T160757Z.txt`.

Backlog item #20 (KR1-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
