### PR TITLE
ops: harden deploy-web.mjs — Vercel CLI timeouts + post-merge probe-only rule (backlog #27)

### DIFF
--- a/ops/deploy-web.mjs
+++ b/ops/deploy-web.mjs
@@ -9,10 +9,17 @@
 //   Gate 1: npx tsc --noEmit clean            (else ALERT, exit 11)
 //   Gate 2: npm run test all green            (else ALERT, exit 12)
 //   Gate 4: version bump + CHANGELOG present  (heuristic warning only)
-//   Deploy: npx vercel --prod --yes           (nonzero -> ALERT, exit 13)
+//   Deploy: npx vercel --prod --yes           (nonzero -> ALERT, exit 13;
+//     hang beyond DEPLOY_TIMEOUT_MS -> child killed, prod probed, ALERT,
+//     exit 13 if prod green / rollback + exit 14 if not - backlog #27)
 //   Post-deploy: synthetic probe; on failure auto-rollback to the last
 //     known-good production deployment, re-probe, ALERT, exit 14. A broken
 //     prod state is never left standing.
+//
+// Deploy-flow rule (DECISIONS 2026-07-12): merge-to-main already deploys via
+// the Vercel git integration, so when the tree is identical to origin/main
+// this wrapper runs probe-only instead of a redundant CLI deploy. The CLI
+// deploy path is for working-tree (pre-merge) ships.
 //
 // The probe is the shared Linux probe ../ops-shared/check-site.sh (writes
 // ops/logs/site-check-*.json + ALERT on failure); if that script is absent
@@ -33,6 +40,11 @@ import {
   versionAndChangelogTouched,
   parseProdDeployment,
   rollbackArgs,
+  spawnOutcome,
+  isRedundantCliDeploy,
+  DEPLOY_TIMEOUT_MS,
+  VERCEL_LS_TIMEOUT_MS,
+  ROLLBACK_TIMEOUT_MS,
 } from './lib/deploy-gates.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -72,6 +84,18 @@ function run(cmd, argv, opts = {}) {
   return r.status ?? 1;
 }
 
+// Like run(), but kills the child if it exceeds timeoutMs (SIGKILL - a wedged
+// Vercel CLI ignored the run-29 wait entirely). Returns { exit, timedOut }.
+function runTimed(cmd, argv, timeoutMs) {
+  const r = spawnSync(cmd, argv, {
+    cwd: ROOT,
+    stdio: 'inherit',
+    timeout: timeoutMs,
+    killSignal: 'SIGKILL',
+  });
+  return spawnOutcome(r);
+}
+
 function gitFiles(...diffArgs) {
   const r = spawnSync('git', ['diff', '--name-only', ...diffArgs], { cwd: ROOT, encoding: 'utf8' });
   return (r.stdout || '').split('\n').map((s) => s.trim());
@@ -108,7 +132,9 @@ function invokeRollback(prev, dryRun) {
     console.log(`[dry-run] would run: npx ${argv.join(' ')}`);
     return 0;
   }
-  return run('npx', argv);
+  const rb = runTimed('npx', argv, ROLLBACK_TIMEOUT_MS);
+  if (rb.timedOut) console.log('WARN: vercel rollback timed out and was killed (exit 124).');
+  return rb.exit;
 }
 
 // ---- Self-test: exercise the auto-rollback branch WITHOUT a live failure ----
@@ -153,6 +179,18 @@ if (hits.length) {
   process.exit(10);
 }
 
+// ---- Deploy-flow rule (DECISIONS 2026-07-12, backlog #27) ----
+// Merging to main IS the production deploy (Vercel git integration). If this
+// tree is identical to origin/main there is nothing for the CLI to ship - it
+// already deployed on merge and gated before merging - so probe-only instead
+// of a redundant CLI deploy (the run-29 30-min hang was exactly this case).
+if (!skipDeploy && isRedundantCliDeploy(changed)) {
+  console.log(
+    'No changes vs origin/main - this tree already shipped via the Vercel git integration on merge. Probe-only (deploy-flow rule, DECISIONS 2026-07-12).'
+  );
+  process.exit(await probeProduction());
+}
+
 // ---- Gate 1: tsc clean ----
 console.log('Gate 1/4: npx tsc --noEmit ...');
 if (run('npx', ['tsc', '--noEmit']) !== 0) {
@@ -183,15 +221,44 @@ if (skipDeploy) {
 // ---- Capture last known-good production deployment (rollback target) ----
 let prev = null;
 try {
-  const ls = spawnSync('npx', ['vercel', 'ls', '--prod', '--yes'], { cwd: ROOT, encoding: 'utf8' });
+  const ls = spawnSync('npx', ['vercel', 'ls', '--prod', '--yes'], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    timeout: VERCEL_LS_TIMEOUT_MS,
+    killSignal: 'SIGKILL',
+  });
   prev = parseProdDeployment(`${ls.stdout || ''}\n${ls.stderr || ''}`);
 } catch {}
 if (prev) console.log(`Known-good production deployment (rollback target): ${prev}`);
 else console.log("WARN: could not resolve current prod deployment; rollback will fall back to 'vercel rollback' (previous).");
 
 // ---- Deploy to production ----
-console.log('Deploying to production: npx vercel --prod ...');
-if (run('npx', ['vercel', '--prod', '--yes']) !== 0) {
+console.log(`Deploying to production: npx vercel --prod (timeout ${DEPLOY_TIMEOUT_MS / 60000} min) ...`);
+const dep = runTimed('npx', ['vercel', '--prod', '--yes'], DEPLOY_TIMEOUT_MS);
+if (dep.timedOut) {
+  // Run-29 class: Vercel-side hung/UNKNOWN deployment. The child is killed;
+  // prod state is unknown, so probe - and roll back if prod is actually broken.
+  console.log(`DEPLOY TIMED OUT after ${DEPLOY_TIMEOUT_MS / 60000} min - child killed. Probing production...`);
+  const hangProbe = await probeProduction();
+  if (hangProbe !== 0) {
+    console.log('Production probe FAILED after deploy hang - auto-rolling-back.');
+    const rb = invokeRollback(prev, false);
+    const reprobe = await probeProduction();
+    writeDeployAlert(
+      'deploy-timeout-rolled-back',
+      `vercel --prod exceeded ${DEPLOY_TIMEOUT_MS / 60000} min (killed) AND the production probe failed; rolled back to '${prev}' (rollback exit=${rb}, re-probe exit=${reprobe}).`
+    );
+    addDeployHealthRow('fail', 'rolled-back', `deploy hang killed; probe failed; rollback exit=${rb} re-probe=${reprobe}`);
+    process.exit(14);
+  }
+  writeDeployAlert(
+    'deploy-timeout',
+    `vercel --prod exceeded ${DEPLOY_TIMEOUT_MS / 60000} min and was killed. Production probe is GREEN (the hung deployment never promoted). Likely a Vercel-side stuck/UNKNOWN deployment - check the dashboard for a stale entry to cancel.`
+  );
+  addDeployHealthRow('fail', 'deploy-timeout', 'vercel --prod hang killed; prod probe green');
+  process.exit(13);
+}
+if (dep.exit !== 0) {
   writeDeployAlert('deploy-failed', 'npx vercel --prod returned non-zero.');
   addDeployHealthRow('fail', 'deploy-error', 'vercel --prod nonzero');
   process.exit(13);

--- a/ops/lib/deploy-gates.mjs
+++ b/ops/lib/deploy-gates.mjs
@@ -43,3 +43,29 @@ export function parseProdDeployment(lsOutput) {
 export function rollbackArgs(prev) {
   return prev ? ['vercel', 'rollback', prev, '--yes'] : ['vercel', 'rollback', '--yes'];
 }
+
+// Timeouts for the Vercel CLI children (backlog #27, from the run-29 incident:
+// `vercel --prod` hung ~30 min on a Vercel-side UNKNOWN deployment with zero
+// builds). A healthy prod deploy completes in single-digit minutes; a stuck
+// one never recovers, so kill it and classify instead of waiting forever.
+export const DEPLOY_TIMEOUT_MS = 15 * 60 * 1000; // vercel --prod
+export const VERCEL_LS_TIMEOUT_MS = 2 * 60 * 1000; // vercel ls (read-only)
+export const ROLLBACK_TIMEOUT_MS = 5 * 60 * 1000; // vercel rollback
+
+// Interpret a spawnSync result including the timeout-kill case: on timeout
+// Node kills the child (status null, signal set, error.code ETIMEDOUT).
+// Returns { exit, timedOut } where exit is a number (never null).
+export function spawnOutcome(r) {
+  const timedOut =
+    r?.error?.code === 'ETIMEDOUT' || (r != null && r.status == null && r.signal != null);
+  return { exit: timedOut ? 124 : r?.status ?? 1, timedOut };
+}
+
+// Deploy-flow rule (DECISIONS 2026-07-12): merging to `main` IS the production
+// deploy (Vercel git integration), so with no committed, staged, or unstaged
+// changes vs origin/main there is nothing for the CLI to ship - a second CLI
+// deploy of the identical tree is redundant (the run-29 hang was exactly
+// this). The wrapper's CLI deploy is for working-tree (pre-merge) ships only.
+export function isRedundantCliDeploy(changedFiles) {
+  return changedFiles.length === 0;
+}

--- a/ops/lib/deploy-gates.test.mjs
+++ b/ops/lib/deploy-gates.test.mjs
@@ -6,6 +6,11 @@ import {
   versionAndChangelogTouched,
   parseProdDeployment,
   rollbackArgs,
+  spawnOutcome,
+  isRedundantCliDeploy,
+  DEPLOY_TIMEOUT_MS,
+  VERCEL_LS_TIMEOUT_MS,
+  ROLLBACK_TIMEOUT_MS,
 } from './deploy-gates.mjs';
 
 describe('GATED_PATTERN / findGatedHits (Charter Sec 3b scanner)', () => {
@@ -109,5 +114,52 @@ describe('rollbackArgs', () => {
   });
   it('falls back to previous-deployment rollback when unresolved', () => {
     expect(rollbackArgs(null)).toEqual(['vercel', 'rollback', '--yes']);
+  });
+});
+
+describe('spawnOutcome (timeout-kill interpretation, backlog #27)', () => {
+  it('flags a timeout via error.code ETIMEDOUT', () => {
+    const err = Object.assign(new Error('spawnSync npx ETIMEDOUT'), { code: 'ETIMEDOUT' });
+    expect(spawnOutcome({ status: null, signal: 'SIGKILL', error: err })).toEqual({
+      exit: 124,
+      timedOut: true,
+    });
+  });
+  it('flags a timeout via null status + kill signal (no error object)', () => {
+    expect(spawnOutcome({ status: null, signal: 'SIGKILL' })).toEqual({
+      exit: 124,
+      timedOut: true,
+    });
+  });
+  it('passes through a clean exit', () => {
+    expect(spawnOutcome({ status: 0, signal: null })).toEqual({ exit: 0, timedOut: false });
+  });
+  it('passes through a nonzero exit', () => {
+    expect(spawnOutcome({ status: 13, signal: null })).toEqual({ exit: 13, timedOut: false });
+  });
+  it('defaults a signal-less null status to exit 1, not a timeout', () => {
+    expect(spawnOutcome({ status: null, signal: null })).toEqual({ exit: 1, timedOut: false });
+  });
+  it('treats a missing result as a plain failure', () => {
+    expect(spawnOutcome(undefined)).toEqual({ exit: 1, timedOut: false });
+  });
+});
+
+describe('isRedundantCliDeploy (deploy-flow rule, DECISIONS 2026-07-12)', () => {
+  it('true when the tree is identical to origin/main (nothing to ship)', () => {
+    expect(isRedundantCliDeploy([])).toBe(true);
+  });
+  it('false when working-tree/unpushed changes exist (pre-merge CLI deploy)', () => {
+    expect(isRedundantCliDeploy(['app/vs/page.tsx'])).toBe(false);
+  });
+});
+
+describe('Vercel CLI timeouts', () => {
+  it('deploy timeout is the longest and all are positive', () => {
+    for (const t of [DEPLOY_TIMEOUT_MS, VERCEL_LS_TIMEOUT_MS, ROLLBACK_TIMEOUT_MS]) {
+      expect(t).toBeGreaterThan(0);
+    }
+    expect(DEPLOY_TIMEOUT_MS).toBeGreaterThan(ROLLBACK_TIMEOUT_MS);
+    expect(ROLLBACK_TIMEOUT_MS).toBeGreaterThan(VERCEL_LS_TIMEOUT_MS);
   });
 });


### PR DESCRIPTION
## What

Implements backlog item **#27** (deploy-web.mjs hardening, from the run-29 incident where `vercel --prod` hung ~30 min in a Vercel-side UNKNOWN deployment with zero builds):

1. **Timeouts on every Vercel CLI child** (deploy 15 min, `ls` 2 min, rollback 5 min; SIGKILL — a wedged CLI may ignore SIGTERM). A hung deploy is killed and classified instead of blocking the run:
   - prod probe green after the kill → `ALERT-deploy` (`deploy-timeout`), health row, exit 13 — the run-29 case, now self-handling.
   - prod probe red after the kill → auto-rollback + re-probe + `ALERT` (`deploy-timeout-rolled-back`), exit 14 — a broken prod is never left standing.
2. **Deploy-flow rule encoded** (DECISIONS 2026-07-12): if the tree is identical to `origin/main` (no committed/staged/unstaged changes), merge-to-main already deployed it via the Vercel **git integration**, so the wrapper runs **probe-only** instead of a redundant CLI deploy. The CLI deploy path is reserved for working-tree (pre-merge) ships. `--skip-deploy` semantics unchanged (still runs gates as a CI-style check).

Pure logic (`spawnOutcome`, `isRedundantCliDeploy`, timeout constants) added to the tested `ops/lib/deploy-gates.mjs` — **9 new unit tests** (suite: 27 files / 369 tests).

## Verification
- `npx tsc --noEmit` clean; `npm run test` 369/369 green.
- Timeout-kill smoke-tested live: a 30s sleep child under a 2s timeout is killed at the deadline (`status=null signal=SIGKILL error=ETIMEDOUT`) and classified `{exit:124, timedOut:true}`; clean exits pass through.
- `--self-test-rollback` re-run end-to-end on the edited wrapper: dry-run rollback + production re-probe exit 0 (`SELFTEST-rollback-20260712T183617Z.txt`).
- The probe-only guard's live trigger (clean main) will be confirmed post-merge with a supervised run.

Non-§3b: ops tooling only — enforces the gates, touches no money/auth/email logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
