### PR TITLE
ops: port content-marker checks to the Linux probe (item 21)

### DIFF
--- a/ops/check-site.mjs
+++ b/ops/check-site.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// Synthetic health probe for app.donatalk.com critical paths (KR1-4).
+// Linux port of ops/check-site.ps1 WITH the content-marker assertions the
+// shared HTTP-200-only probe lacked (backlog item 21): each route must return
+// 200 AND contain its expected marker substring.
+//
+// Read-only: fetches public routes only. NO test users created (booking/signup
+// are behind auth + PayPal - probing them live would touch money-adjacent
+// flows, which the Charter fences off).
+//
+// Writes ops/logs/site-check-<ts>.json in the same shape as
+// ops-shared/check-site.sh (which delegates to this script when present), plus
+// ALERT-check-site-<ts>.txt on failure. Exit 0 = healthy, 1 = failure.
+//
+// Usage: node ops/check-site.mjs
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  CHECKS,
+  DEFAULT_BASE,
+  FETCH_TIMEOUT_MS,
+  evaluateCheck,
+  buildArtifact,
+  utcStamp,
+} from './lib/site-probe.mjs';
+
+const OPS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const LOG_DIR = path.join(OPS_DIR, 'logs');
+const BASE = process.env.NEXT_PUBLIC_BASE_URL || DEFAULT_BASE;
+
+mkdirSync(LOG_DIR, { recursive: true });
+const ts = utcStamp();
+
+const results = [];
+for (const c of CHECKS) {
+  const url = `${BASE}${c.path}`;
+  let status = 'ERR';
+  let body = '';
+  try {
+    const res = await fetch(url, { redirect: 'follow', signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+    status = res.status;
+    body = await res.text();
+  } catch (e) {
+    console.log(`  ${url} -> ERROR ${String(e.message || e).slice(0, 80)}`);
+  }
+  const { ok, markerOk } = evaluateCheck(status, body, c.marker);
+  results.push({ url, status, ok, marker: c.marker, marker_ok: markerOk });
+  console.log(`  ${url} -> ${status}${ok ? ' ok' : ` FAIL${status === 200 && !markerOk ? ` (marker "${c.marker}" missing)` : ''}`}`);
+}
+
+const artifact = buildArtifact(ts, BASE, results);
+const artifactPath = path.join(LOG_DIR, `site-check-${ts}.json`);
+writeFileSync(artifactPath, JSON.stringify(artifact) + '\n');
+
+if (artifact.failed > 0) {
+  const alertPath = path.join(LOG_DIR, `ALERT-check-site-${ts}.txt`);
+  writeFileSync(
+    alertPath,
+    `Site probe FAILED at ${ts} against ${BASE} (${artifact.failed} of ${results.length} checks)\n` +
+      JSON.stringify(artifact, null, 2) + '\n'
+  );
+  console.log(`PROBE FAILED - wrote ${alertPath}`);
+  process.exit(1);
+}
+console.log(`PROBE OK - ${BASE} all critical paths healthy (200 + markers).`);
+process.exit(0);

--- a/ops/lib/site-probe.mjs
+++ b/ops/lib/site-probe.mjs
@@ -1,0 +1,42 @@
+// Pure logic for the donatalk synthetic site probe (ops/check-site.mjs).
+// Restores the content-marker assertions the Windows probe (check-site.ps1)
+// had and the Linux shared probe (ops-shared/check-site.sh) lost in the port:
+// a route is healthy only if it returns 200 AND its HTML contains the marker.
+// Marker match is case-insensitive, matching PowerShell's -match default.
+
+// route -> substring that must appear in the HTML for the path to be healthy.
+export const CHECKS = [
+  { path: '/', marker: 'DonaTalk' },
+  { path: '/listeners', marker: 'listener' },
+  { path: '/login', marker: 'DonaTalk' },
+];
+
+export const DEFAULT_BASE = 'https://app.donatalk.com';
+export const FETCH_TIMEOUT_MS = 30000;
+
+// status: number|'ERR'; body: string ('' on fetch error).
+export function evaluateCheck(status, body, marker) {
+  const statusOk = status === 200;
+  const markerOk = statusOk && String(body).toLowerCase().includes(marker.toLowerCase());
+  return { statusOk, markerOk, ok: statusOk && markerOk };
+}
+
+// Same artifact shape as ops-shared/check-site.sh writes (get-metrics.mjs and
+// deploy-web.mjs key off `timestamp` + `overall`); marker fields are additive.
+export function buildArtifact(ts, base, results) {
+  const failed = results.filter((r) => !r.ok).length;
+  return {
+    timestamp: ts,
+    business: 'donatalk',
+    host: 'linux',
+    overall: failed === 0 ? 'pass' : 'fail',
+    failed,
+    full_probe: 'skipped', // no transactional (signup/login) probe for donatalk yet
+    markers: 'checked',
+    results,
+  };
+}
+
+export function utcStamp(d = new Date()) {
+  return d.toISOString().replace(/[-:]/g, '').replace(/\.\d+Z$/, 'Z');
+}

--- a/ops/lib/site-probe.test.mjs
+++ b/ops/lib/site-probe.test.mjs
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { CHECKS, evaluateCheck, buildArtifact, utcStamp } from './site-probe.mjs';
+
+describe('CHECKS (parity with check-site.ps1 marker spec)', () => {
+  it('covers the three critical paths with the original markers', () => {
+    expect(CHECKS).toEqual([
+      { path: '/', marker: 'DonaTalk' },
+      { path: '/listeners', marker: 'listener' },
+      { path: '/login', marker: 'DonaTalk' },
+    ]);
+  });
+});
+
+describe('evaluateCheck', () => {
+  it('passes on 200 + marker present', () => {
+    expect(evaluateCheck(200, '<html>Welcome to DonaTalk</html>', 'DonaTalk')).toEqual({
+      statusOk: true,
+      markerOk: true,
+      ok: true,
+    });
+  });
+
+  it('is case-insensitive like PowerShell -match', () => {
+    expect(evaluateCheck(200, 'browse LISTENERS here', 'listener').ok).toBe(true);
+    expect(evaluateCheck(200, 'donatalk footer', 'DonaTalk').ok).toBe(true);
+  });
+
+  it('fails on 200 with marker missing (the case the HTTP-only probe missed)', () => {
+    const r = evaluateCheck(200, '<html>Application error</html>', 'DonaTalk');
+    expect(r.statusOk).toBe(true);
+    expect(r.markerOk).toBe(false);
+    expect(r.ok).toBe(false);
+  });
+
+  it('fails on non-200 regardless of body', () => {
+    expect(evaluateCheck(500, 'DonaTalk', 'DonaTalk').ok).toBe(false);
+    expect(evaluateCheck(301, 'DonaTalk', 'DonaTalk').ok).toBe(false);
+  });
+
+  it('fails on fetch error (status ERR, empty body)', () => {
+    expect(evaluateCheck('ERR', '', 'DonaTalk').ok).toBe(false);
+  });
+});
+
+describe('buildArtifact (shape consumed by get-metrics.mjs / deploy-web.mjs)', () => {
+  const okResult = { url: 'https://app.donatalk.com/', status: 200, ok: true, marker: 'DonaTalk', marker_ok: true };
+  const badResult = { url: 'https://app.donatalk.com/login', status: 200, ok: false, marker: 'DonaTalk', marker_ok: false };
+
+  it('reports pass with zero failures', () => {
+    const a = buildArtifact('20260713T000000Z', 'https://app.donatalk.com', [okResult]);
+    expect(a.overall).toBe('pass');
+    expect(a.failed).toBe(0);
+    expect(a.timestamp).toBe('20260713T000000Z'); // get-metrics.mjs staleness check reads this
+    expect(a.business).toBe('donatalk');
+    expect(a.full_probe).toBe('skipped');
+  });
+
+  it('reports fail and counts failed checks', () => {
+    const a = buildArtifact('20260713T000000Z', 'https://app.donatalk.com', [okResult, badResult]);
+    expect(a.overall).toBe('fail');
+    expect(a.failed).toBe(1);
+  });
+});
+
+describe('utcStamp', () => {
+  it('formats like the shared probe (yyyyMMddTHHmmssZ)', () => {
+    expect(utcStamp(new Date('2026-07-13T00:30:01.123Z'))).toBe('20260713T003001Z');
+  });
+});


### PR DESCRIPTION
## What
Backlog item 21 (KR1-4): the shared Linux probe (`ops-shared/check-site.sh`) only checks HTTP 200; the original Windows `check-site.ps1` also asserted a content marker per route (`/` -> "DonaTalk", `/listeners` -> "listener", `/login` -> "DonaTalk"), which catches 200-but-broken renders (e.g. a Next.js error page served with 200).

- **`ops/check-site.mjs`** — repo-owned Node probe: 200 + case-insensitive marker per critical path; writes `site-check-<ts>.json` in the exact shape the shared probe writes (`timestamp`/`overall` are what `get-metrics.mjs` + `deploy-web.mjs` consume; marker fields are additive) + `ALERT-check-site-<ts>.txt` on failure; exit 0/1.
- **`ops/lib/site-probe.mjs`** — pure check/artifact logic, unit-tested (**9 tests**, suite now 28 files / 378).
- Mirrors the TierUp pattern: the shared `check-site.sh` delegates to `$REPO/ops/check-site.mjs` when present (host-side one-line edit, applied after this merges so main has the script first).

## Gates
- `npx tsc --noEmit` clean
- `npm run test` 378/378 pass
- Live-verified against production: all 3 paths 200 + markers pass
- Non-§3b (read-only probe of public pages); ops-only -> no product version bump (2026-07-10 convention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
