### PR TITLE
seo: /vs curated-vs-self-serve category context (item 24, v0.20.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to DonaTalk are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [SemVer](https://semver.org/).
 
+## [0.20.0] - 2026-07-13
+
+### Added (SEO — `/vs` made aware of the curated donation-for-meeting category)
+- `app/vs/page.tsx` — new "Within the category: curated vs. self-serve" section (two cards) + matching FAQ entry (auto-included in the FAQPage JSON-LD) + two category keywords (`donation for a meeting`, `executive meetings for charity`). The 2026-07-12 competitor scan found that donation-for-meeting platforms also exist in curated/enterprise form (vetted executive panels, fixed-price meetings, share-to-charity), so the category page now describes that model honestly at category level — no competitor named, no "first/only" claims (Charter Sec 6) — and positions DonaTalk by its real differentiators: self-serve, any vertical, donation set by the pitcher (from $10) to a listener-chosen cause, decline = no charge, 4.9% fee. Static content only, non-§3b.
+
 ## [0.19.2] - 2026-07-12
 
 ### Security (dependency updates — Dependabot triage, no code changes)

--- a/app/vs/page.tsx
+++ b/app/vs/page.tsx
@@ -4,9 +4,12 @@
 // Static server component — no data reads, safe to prerender. Compares three
 // *approaches* (cold email, paid gifting, donation-based outreach) at the
 // category level; it never names or disparages a specific competitor product,
-// per the Charter Sec 6 content rules (truthful, non-defamatory). First-party
-// claims (donation-to-book, listener picks the cause, 4.9% fee, decline = no
-// charge) mirror the live product.
+// per the Charter Sec 6 content rules (truthful, non-defamatory). This
+// includes the curated-vs-self-serve section: other donation-for-meeting
+// platforms exist (curated/enterprise), so we describe that model honestly at
+// category level and never claim "first/only". First-party claims
+// (donation-to-book, listener picks the cause, 4.9% fee, decline = no charge)
+// mirror the live product.
 
 import Link from 'next/link';
 import type { Metadata } from 'next';
@@ -33,6 +36,8 @@ export const metadata: Metadata = {
     'authentic sales outreach',
     'AI outreach alternative',
     'outbound is dead alternatives',
+    'donation for a meeting',
+    'executive meetings for charity',
   ],
   alternates: { canonical: '/vs' },
   openGraph: {
@@ -139,6 +144,21 @@ const DIFFERENTIATORS: { icon: string; title: string; body: string }[] = [
   },
 ];
 
+const MODELS: { icon: string; title: string; body: string }[] = [
+  {
+    icon: '🏛️',
+    title: 'Curated executive marketplaces',
+    body:
+      "Some donation-for-meeting platforms are curated: a vetted, invite-only panel of senior executives takes fixed-price discovery meetings — often several hundred dollars each — with a share of the fee passed to the executive's chosen charity. A strong fit if you sell to enterprises and the exact executive you need is on the panel.",
+  },
+  {
+    icon: '🚀',
+    title: 'Self-serve, any seller — DonaTalk',
+    body:
+      'DonaTalk is the self-serve take on the same idea: anyone can list themselves as a listener, any seller in any vertical can pitch, and you set the donation (from $10) to a cause the recipient chooses. No panel to be accepted into, no fixed price — and if the meeting is declined, nothing is charged. DonaTalk keeps a 4.9% fee on committed donations.',
+  },
+];
+
 const STEPS: string[] = [
   'Find a person on DonaTalk and a cause they support that you want to back.',
   'Commit a donation (from $10) to request 15 minutes of their time.',
@@ -157,6 +177,10 @@ const FAQ: { q: string; a: string }[] = [
   {
     q: 'Is this just paid gifting with extra steps?',
     a: "No. Paid gifting rewards the recipient personally, which can feel transactional and may conflict with corporate gifting policies. A donation goes to a non-profit the recipient selects, so the value lands on a cause rather than a person.",
+  },
+  {
+    q: 'Are there other donation-for-meeting platforms?',
+    a: 'Yes — trading a charitable donation for a business meeting also exists in curated, enterprise-focused forms, where a vetted panel of executives takes fixed-price meetings (often several hundred dollars, with a share going to the executive’s chosen charity). DonaTalk is the self-serve version of the model: any listener can join and any seller can pitch in any vertical, you set the donation amount (from $10) to a cause the recipient chooses, and nothing is charged if the meeting is declined.',
   },
   {
     q: 'What does it cost, and what if the meeting is declined?',
@@ -413,6 +437,17 @@ export default function VsPage() {
               <DiffIcon aria-hidden>{d.icon}</DiffIcon>
               <DiffTitle>{d.title}</DiffTitle>
               <DiffBody>{d.body}</DiffBody>
+            </DiffCard>
+          ))}
+        </CardGrid>
+
+        <SectionHeading>Within the category: curated vs. self-serve</SectionHeading>
+        <CardGrid>
+          {MODELS.map((m) => (
+            <DiffCard key={m.title}>
+              <DiffIcon aria-hidden>{m.icon}</DiffIcon>
+              <DiffTitle>{m.title}</DiffTitle>
+              <DiffBody>{m.body}</DiffBody>
             </DiffCard>
           ))}
         </CardGrid>

--- a/docs/developer-reference.md
+++ b/docs/developer-reference.md
@@ -1,6 +1,6 @@
 # DonaTalk - Developer Reference
 
-> Last updated: 2026-07-12 | Version: 0.19.2
+> Last updated: 2026-07-13 | Version: 0.20.0
 
 ## Project Overview
 

--- a/docs/product-reference.md
+++ b/docs/product-reference.md
@@ -1,6 +1,6 @@
 # DonaTalk - Product Reference
 
-> Last updated: 2026-07-12 | Version: 0.19.2
+> Last updated: 2026-07-13 | Version: 0.20.0
 
 ## Product Vision
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pitcher-platform",
-  "version": "0.19.2",
+  "version": "0.20.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## What
Backlog item 24 (MeetMagic-aware content refresh): `app/vs/page.tsx` gains a "Within the category: curated vs. self-serve" section (two cards), a matching FAQ entry (auto-included in FAQPage JSON-LD), and two category keywords (`donation for a meeting`, `executive meetings for charity`). Version 0.19.2 → 0.20.0 + CHANGELOG + reference docs.

## Why
The 2026-07-12 competitor scan (research/2026-07-12-keywords.md §2a) found donation-for-meeting platforms also exist in curated/enterprise form (vetted exec panels, fixed-price ~$700, share-to-charity). The category page now describes that honestly at category level and positions DonaTalk by its real differentiators (self-serve, any vertical, pitcher-set donation from $10 to a listener-chosen cause, decline = no charge, 4.9% fee).

## §6 / §3b
- No competitor named, no "first/only" claims, first-party claims mirror the live product.
- Static content only — no auth/money/email surface touched (non-§3b).

## Gates
- `npx tsc --noEmit` clean
- `npm run test` — 28 files / 378 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)